### PR TITLE
feat: enhance uninstall script with --all option for complete cleanup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,11 +17,20 @@ VERCELAB_TRAEFIK_CERTS_DIR=/opt/vercelab/traefik/certs
 VERCELAB_APPS_DIR=/opt/vercelab/data/apps
 VERCELAB_LOGS_DIR=/opt/vercelab/data/logs
 VERCELAB_LOCKS_DIR=/opt/vercelab/data/locks
-VERCELAB_DATABASE_PATH=/opt/vercelab/data/db/vercelab.sqlite
+VERCELAB_POSTGRES_DATA_DIR=/opt/vercelab/data/postgres
+VERCELAB_INFLUXDB_DATA_DIR=/opt/vercelab/data/influxdb
 VERCELAB_DOCKER_SOCKET_PATH=/var/run/docker.sock
 
-VERCELAB_DATABASE_PROVIDER=sqlite
-VERCELAB_POSTGRES_URL=
+VERCELAB_DATABASE_PROVIDER=postgres
+VERCELAB_POSTGRES_URL=postgres://vercelab:replace-me-postgres-password@postgres:5432/vercelab
+VERCELAB_POSTGRES_USER=vercelab
+VERCELAB_POSTGRES_PASSWORD=replace-me-postgres-password
+VERCELAB_POSTGRES_DB=vercelab
+
+VERCELAB_INFLUXDB_URL=http://influxdb:8181
+VERCELAB_INFLUXDB_DATABASE=vercelab_metrics
+VERCELAB_INFLUXDB_TOKEN=
+VERCELAB_INFLUXDB_RETENTION_DAYS=90
 
 VERCELAB_ENCRYPTION_SECRET=replace-me-with-a-random-secret
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # Vercelab
 
-Vercelab is a self-hosted homelab deployment control plane built with Next.js 16. It clones a GitHub repository, detects a root `Dockerfile` or `docker-compose.yml`, stores deployment state in SQLite, encrypts GitHub tokens at rest, and exposes each deployed app behind Traefik with self-signed HTTPS.
+Vercelab is a self-hosted homelab deployment control plane built with Next.js 16. It clones a GitHub repository, detects a root `Dockerfile` or `docker-compose.yml`, stores control-plane state in PostgreSQL, stores metrics in InfluxDB 3 Core, encrypts GitHub tokens at rest, and exposes each deployed app behind Traefik with self-signed HTTPS.
 
 ## Current scope
 
 - Next.js 16 control plane with server actions
-- SQLite persistence with encrypted GitHub personal access tokens
+- PostgreSQL persistence with encrypted GitHub personal access tokens
+- InfluxDB 3 Core storage for host and container metrics
 - Deployment engine for root `Dockerfile` and `docker-compose.yml` repositories
 - Traefik routing on a shared Docker network
 - Ubuntu installer for the control-plane stack, wildcard self-signed TLS, and host-path validation
@@ -43,7 +44,7 @@ Any runtime variable listed below can be exported before running `./install.sh`.
 The installer is a full bootstrap script for a plain Ubuntu server. It will:
 
 - install Node.js and pnpm on the host
-- install the native toolchain needed by packages such as `better-sqlite3`
+- install the host packages required by the stack bootstrap scripts
 - install and pin Docker Engine `28.x` plus the Compose plugin, because Traefik's Docker provider is not compatible with Docker `29.x` on this stack
 - run `pnpm install --frozen-lockfile` and a host-side `pnpm run build` smoke test
 - create a shared host root under `/opt/vercelab` by default
@@ -63,7 +64,8 @@ Production storage defaults live under `VERCELAB_HOST_ROOT`, which defaults to `
 - `/opt/vercelab/data/apps`: cloned deployment repositories and generated compose overrides
 - `/opt/vercelab/data/logs`: deployment logs
 - `/opt/vercelab/data/locks`: deployment lock files
-- `/opt/vercelab/data/db/vercelab.sqlite`: SQLite database
+- `/opt/vercelab/data/postgres`: PostgreSQL data directory
+- `/opt/vercelab/data/influxdb`: InfluxDB 3 Core data directory
 - `/opt/vercelab/traefik/dynamic/tls.yml`: Traefik TLS dynamic config
 - `/opt/vercelab/traefik/certs/wildcard.crt`: self-signed wildcard certificate
 - `/opt/vercelab/traefik/certs/wildcard.key`: private key for the wildcard certificate
@@ -73,33 +75,42 @@ Local development has a different fallback layout when you do not set production
 - `./data/apps`
 - `./data/logs`
 - `./data/locks`
-- `./data/vercelab.sqlite`
+- `./data/postgres`
+- `./data/influxdb`
 
 ## Default runtime variables
 
 These are the defaults the installer writes into `.env` unless you override them.
 
-| Variable                       | Default                                                                      | Notes                                                                               |
-| ------------------------------ | ---------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
-| `NODE_ENV`                     | `production`                                                                 | Runtime mode for the control plane container                                        |
-| `HOSTNAME`                     | `0.0.0.0`                                                                    | Bind address inside the container                                                   |
-| `PORT`                         | `3000`                                                                       | Internal port Traefik forwards to                                                   |
-| `VERCELAB_BASE_DOMAIN`         | auto-derived from the host IPv4 as `<ip>.sslip.io`, fallback `myhomelan.com` | Base wildcard domain for deployed apps                                              |
-| `VERCELAB_ADMIN_HOST`          | `vercelab.${VERCELAB_BASE_DOMAIN}`                                           | Control plane hostname                                                              |
-| `VERCELAB_PROXY_NETWORK`       | `vercelab_proxy`                                                             | Shared Docker network for Traefik and managed apps                                  |
-| `VERCELAB_PROXY_ENTRYPOINT`    | `websecure`                                                                  | Traefik HTTPS entrypoint                                                            |
-| `VERCELAB_HOST_ROOT`           | `/opt/vercelab`                                                              | Shared host path mounted into the control-plane container at the same absolute path |
-| `VERCELAB_DATA_ROOT`           | `${VERCELAB_HOST_ROOT}/data`                                                 | Parent directory for apps, logs, locks, and the database                            |
-| `VERCELAB_TRAEFIK_DYNAMIC_DIR` | `${VERCELAB_HOST_ROOT}/traefik/dynamic`                                      | Generated Traefik dynamic config location                                           |
-| `VERCELAB_TRAEFIK_CERTS_DIR`   | `${VERCELAB_HOST_ROOT}/traefik/certs`                                        | Wildcard certificate and key                                                        |
-| `VERCELAB_APPS_DIR`            | `${VERCELAB_DATA_ROOT}/apps`                                                 | Cloned app repositories                                                             |
-| `VERCELAB_LOGS_DIR`            | `${VERCELAB_DATA_ROOT}/logs`                                                 | Deployment logs                                                                     |
-| `VERCELAB_LOCKS_DIR`           | `${VERCELAB_DATA_ROOT}/locks`                                                | Deployment lock files                                                               |
-| `VERCELAB_DATABASE_PATH`       | `${VERCELAB_DATA_ROOT}/db/vercelab.sqlite`                                   | SQLite database path                                                                |
-| `VERCELAB_DOCKER_SOCKET_PATH`  | `/var/run/docker.sock`                                                       | Host Docker socket passed into Traefik and the control plane                        |
-| `VERCELAB_DATABASE_PROVIDER`   | `sqlite`                                                                     | `postgres` is accepted, but requires `VERCELAB_POSTGRES_URL`                        |
-| `VERCELAB_POSTGRES_URL`        | empty                                                                        | Required only when `VERCELAB_DATABASE_PROVIDER=postgres`                            |
-| `VERCELAB_ENCRYPTION_SECRET`   | auto-generated 64-hex-character secret when unset                            | Used to encrypt stored GitHub tokens                                                |
+| Variable                           | Default                                                                      | Notes                                                                               |
+| ---------------------------------- | ---------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
+| `NODE_ENV`                         | `production`                                                                 | Runtime mode for the control plane container                                        |
+| `HOSTNAME`                         | `0.0.0.0`                                                                    | Bind address inside the container                                                   |
+| `PORT`                             | `3000`                                                                       | Internal port Traefik forwards to                                                   |
+| `VERCELAB_BASE_DOMAIN`             | auto-derived from the host IPv4 as `<ip>.sslip.io`, fallback `myhomelan.com` | Base wildcard domain for deployed apps                                              |
+| `VERCELAB_ADMIN_HOST`              | `vercelab.${VERCELAB_BASE_DOMAIN}`                                           | Control plane hostname                                                              |
+| `VERCELAB_PROXY_NETWORK`           | `vercelab_proxy`                                                             | Shared Docker network for Traefik and managed apps                                  |
+| `VERCELAB_PROXY_ENTRYPOINT`        | `websecure`                                                                  | Traefik HTTPS entrypoint                                                            |
+| `VERCELAB_HOST_ROOT`               | `/opt/vercelab`                                                              | Shared host path mounted into the control-plane container at the same absolute path |
+| `VERCELAB_DATA_ROOT`               | `${VERCELAB_HOST_ROOT}/data`                                                 | Parent directory for apps, logs, locks, and the database                            |
+| `VERCELAB_TRAEFIK_DYNAMIC_DIR`     | `${VERCELAB_HOST_ROOT}/traefik/dynamic`                                      | Generated Traefik dynamic config location                                           |
+| `VERCELAB_TRAEFIK_CERTS_DIR`       | `${VERCELAB_HOST_ROOT}/traefik/certs`                                        | Wildcard certificate and key                                                        |
+| `VERCELAB_APPS_DIR`                | `${VERCELAB_DATA_ROOT}/apps`                                                 | Cloned app repositories                                                             |
+| `VERCELAB_LOGS_DIR`                | `${VERCELAB_DATA_ROOT}/logs`                                                 | Deployment logs                                                                     |
+| `VERCELAB_LOCKS_DIR`               | `${VERCELAB_DATA_ROOT}/locks`                                                | Deployment lock files                                                               |
+| `VERCELAB_POSTGRES_DATA_DIR`       | `${VERCELAB_DATA_ROOT}/postgres`                                             | PostgreSQL data directory                                                           |
+| `VERCELAB_INFLUXDB_DATA_DIR`       | `${VERCELAB_DATA_ROOT}/influxdb`                                             | InfluxDB 3 Core data directory                                                      |
+| `VERCELAB_DOCKER_SOCKET_PATH`      | `/var/run/docker.sock`                                                       | Host Docker socket passed into Traefik and the control plane                        |
+| `VERCELAB_DATABASE_PROVIDER`       | `postgres`                                                                   | PostgreSQL is required in this stack                                                |
+| `VERCELAB_POSTGRES_URL`            | `postgres://vercelab:...@postgres:5432/vercelab`                             | Control-plane relational database connection URL                                    |
+| `VERCELAB_POSTGRES_USER`           | `vercelab`                                                                   | Postgres container username                                                         |
+| `VERCELAB_POSTGRES_PASSWORD`       | generated by installer                                                       | Postgres container password                                                         |
+| `VERCELAB_POSTGRES_DB`             | `vercelab`                                                                   | Postgres database name                                                              |
+| `VERCELAB_INFLUXDB_URL`            | `http://influxdb:8181`                                                       | InfluxDB 3 Core write endpoint                                                      |
+| `VERCELAB_INFLUXDB_DATABASE`       | `vercelab_metrics`                                                           | InfluxDB database for metrics                                                       |
+| `VERCELAB_INFLUXDB_TOKEN`          | empty                                                                        | Optional InfluxDB API token                                                         |
+| `VERCELAB_INFLUXDB_RETENTION_DAYS` | `90`                                                                         | Desired metrics retention period                                                    |
+| `VERCELAB_ENCRYPTION_SECRET`       | auto-generated 64-hex-character secret when unset                            | Used to encrypt stored GitHub tokens                                                |
 
 ## Reinstall
 
@@ -167,13 +178,19 @@ Also remove Docker images labeled for Vercelab compose projects:
 ./uninstall.sh --purge --purge-images
 ```
 
-`uninstall.sh` intentionally leaves Docker Engine, the Docker Compose plugin, Node.js, and pnpm installed on the host. That keeps reinstall simple and avoids removing software the host may be using for other workloads.
+Remove everything above and also remove host tooling installed by `install.sh` (Docker Engine and Compose plugins, Node.js, pnpm) plus local repo build artifacts (`node_modules`, `.next`):
+
+```bash
+./uninstall.sh --all
+```
+
+`uninstall.sh` intentionally leaves Docker Engine, the Docker Compose plugin, Node.js, and pnpm installed on the host unless you explicitly pass `--all`.
 
 ## Why the shared host root matters
 
 Vercelab talks to the host Docker daemon through the host Docker socket. That means Docker build contexts and bind mounts referenced by deployment compose files must exist at the same absolute path on both the host and inside the control-plane container.
 
-The root stack handles this by mounting `VERCELAB_HOST_ROOT` into the container at the exact same absolute path. Keep deployment workspaces, logs, locks, and the SQLite database under that root.
+The root stack handles this by mounting `VERCELAB_HOST_ROOT` into the container at the exact same absolute path. Keep deployment workspaces, logs, locks, PostgreSQL data, and InfluxDB data under that root.
 
 ## Runtime files
 
@@ -182,21 +199,21 @@ The root stack handles this by mounting `VERCELAB_HOST_ROOT` into the container 
 - `docker-compose.yml`: Traefik plus the Vercelab control plane
 - `Dockerfile`: standalone Next.js production image with Git and Docker CLI tooling
 - `install.sh`: Ubuntu bootstrapper for Docker, TLS assets, and the control-plane stack
-- `uninstall.sh`: removes the control plane and managed deployments, with optional purge flags for data and images
+- `uninstall.sh`: removes the control plane and managed deployments, supports `--purge`, and supports destructive `--all` cleanup that also removes host tooling installed by `install.sh`
 
 ## Important environment variables
 
 - `VERCELAB_BASE_DOMAIN`: wildcard domain for deployed apps such as `myhomelan.com`
 - `VERCELAB_ADMIN_HOST`: full host name for the control plane such as `vercelab.myhomelan.com`
 - `VERCELAB_HOST_ROOT`: shared absolute host path mounted into the app container at the same path
-- `VERCELAB_APPS_DIR`, `VERCELAB_LOGS_DIR`, `VERCELAB_LOCKS_DIR`, `VERCELAB_DATABASE_PATH`: explicit managed paths written into `.env` on install
+- `VERCELAB_APPS_DIR`, `VERCELAB_LOGS_DIR`, `VERCELAB_LOCKS_DIR`, `VERCELAB_POSTGRES_DATA_DIR`, `VERCELAB_INFLUXDB_DATA_DIR`: explicit managed paths written into `.env` on install
 - `VERCELAB_DOCKER_SOCKET_PATH`: Docker socket passed through to the control plane and Traefik
 - `VERCELAB_PROXY_NETWORK`: shared Docker network Traefik and deployed apps use
 - `VERCELAB_ENCRYPTION_SECRET`: secret used to encrypt stored GitHub tokens
 
 ## Health and readiness
 
-`/api/health` now checks more than SQLite. In production it also verifies:
+`/api/health` now checks full platform readiness. In production it verifies:
 
 - the Docker socket exists
 - the Docker daemon is reachable

--- a/app/api/deployments/[deploymentId]/logs/route.ts
+++ b/app/api/deployments/[deploymentId]/logs/route.ts
@@ -32,7 +32,7 @@ export async function GET(
     const payload =
       logType === "container"
         ? await readDeploymentContainerLog(deploymentId)
-        : readDeploymentBuildLog(deploymentId);
+        : await readDeploymentBuildLog(deploymentId);
 
     return Response.json(payload);
   } catch (error) {

--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -6,7 +6,7 @@ export const dynamic = "force-dynamic";
 
 export async function GET() {
   const config = getAppConfig();
-  const database = getDatabaseHealth();
+  const database = await getDatabaseHealth();
   const platform = await getPlatformHealth();
 
   return Response.json(

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -16,6 +16,7 @@ function getSearchParamValue(value: string | string[] | undefined) {
 
 export default async function Home({ searchParams }: HomeProps) {
   const params = await searchParams;
+  const dashboardData = await listDashboardData();
   const activeSection =
     getSearchParamValue(params.section) === "git" ? "git" : "overview";
   const status = getSearchParamValue(params.status);
@@ -24,7 +25,7 @@ export default async function Home({ searchParams }: HomeProps) {
   return (
     <MetricsDashboard
       baseDomain={getAppConfig().baseDomain}
-      dashboardData={listDashboardData()}
+      dashboardData={dashboardData}
       flashMessage={
         status === "success" || status === "error"
           ? {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,48 @@
 name: vercelab
 
 services:
+  postgres:
+    image: postgres:16-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: ${VERCELAB_POSTGRES_USER:-vercelab}
+      POSTGRES_PASSWORD: ${VERCELAB_POSTGRES_PASSWORD:-vercelab}
+      POSTGRES_DB: ${VERCELAB_POSTGRES_DB:-vercelab}
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "pg_isready -U ${VERCELAB_POSTGRES_USER:-vercelab} -d ${VERCELAB_POSTGRES_DB:-vercelab}",
+        ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 15s
+    volumes:
+      - ${VERCELAB_POSTGRES_DATA_DIR:-/opt/vercelab/data/postgres}:/var/lib/postgresql/data
+    networks:
+      - proxy
+
+  influxdb:
+    image: influxdb:3-core
+    restart: unless-stopped
+    command:
+      - influxdb3
+      - serve
+      - --node-id=vercelab-node
+      - --object-store=file
+      - --data-dir=/var/lib/influxdb3/data
+    healthcheck:
+      test: [CMD, influxdb3, show, databases]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 15s
+    volumes:
+      - ${VERCELAB_INFLUXDB_DATA_DIR:-/opt/vercelab/data/influxdb}:/var/lib/influxdb3/data
+    networks:
+      - proxy
+
   traefik:
     image: traefik:v3.0
     restart: unless-stopped
@@ -42,9 +84,22 @@ services:
       VERCELAB_APPS_DIR: ${VERCELAB_APPS_DIR:-/opt/vercelab/data/apps}
       VERCELAB_LOGS_DIR: ${VERCELAB_LOGS_DIR:-/opt/vercelab/data/logs}
       VERCELAB_LOCKS_DIR: ${VERCELAB_LOCKS_DIR:-/opt/vercelab/data/locks}
-      VERCELAB_DATABASE_PATH: ${VERCELAB_DATABASE_PATH:-/opt/vercelab/data/db/vercelab.sqlite}
+      VERCELAB_DATABASE_PROVIDER: ${VERCELAB_DATABASE_PROVIDER:-postgres}
+      VERCELAB_POSTGRES_URL: ${VERCELAB_POSTGRES_URL:-postgres://vercelab:vercelab@postgres:5432/vercelab}
+      VERCELAB_POSTGRES_USER: ${VERCELAB_POSTGRES_USER:-vercelab}
+      VERCELAB_POSTGRES_PASSWORD: ${VERCELAB_POSTGRES_PASSWORD:-vercelab}
+      VERCELAB_POSTGRES_DB: ${VERCELAB_POSTGRES_DB:-vercelab}
+      VERCELAB_INFLUXDB_URL: ${VERCELAB_INFLUXDB_URL:-http://influxdb:8181}
+      VERCELAB_INFLUXDB_DATABASE: ${VERCELAB_INFLUXDB_DATABASE:-vercelab_metrics}
+      VERCELAB_INFLUXDB_TOKEN: ${VERCELAB_INFLUXDB_TOKEN:-}
+      VERCELAB_INFLUXDB_RETENTION_DAYS: ${VERCELAB_INFLUXDB_RETENTION_DAYS:-90}
       VERCELAB_DOCKER_SOCKET_PATH: ${VERCELAB_DOCKER_SOCKET_PATH:-/var/run/docker.sock}
       VERCELAB_HOST_PROC_PATH: ${VERCELAB_HOST_PROC_PATH:-/host/proc}
+    depends_on:
+      postgres:
+        condition: service_healthy
+      influxdb:
+        condition: service_healthy
     healthcheck:
       test:
         [

--- a/install.sh
+++ b/install.sh
@@ -405,7 +405,7 @@ ensure_path_inside_root() {
 }
 
 gather_configuration() {
-  local existing_node_env existing_runtime_host existing_port existing_base_domain existing_admin_host existing_host_root existing_data_root existing_dynamic_dir existing_certs_dir existing_proxy_network existing_proxy_entrypoint existing_socket existing_apps_dir existing_logs_dir existing_locks_dir existing_database_provider existing_database_path existing_postgres_url existing_secret existing_github_token default_base_domain
+  local existing_node_env existing_runtime_host existing_port existing_base_domain existing_admin_host existing_host_root existing_data_root existing_dynamic_dir existing_certs_dir existing_proxy_network existing_proxy_entrypoint existing_socket existing_apps_dir existing_logs_dir existing_locks_dir existing_database_provider existing_postgres_url existing_postgres_user existing_postgres_password existing_postgres_db existing_postgres_data_dir existing_influx_url existing_influx_database existing_influx_token existing_influx_retention_days existing_influx_data_dir existing_secret existing_github_token default_base_domain
 
   existing_node_env="$(read_env_value NODE_ENV)"
   existing_runtime_host="$(read_env_value HOSTNAME)"
@@ -424,8 +424,16 @@ gather_configuration() {
   existing_logs_dir="$(read_env_value VERCELAB_LOGS_DIR)"
   existing_locks_dir="$(read_env_value VERCELAB_LOCKS_DIR)"
   existing_database_provider="$(read_env_value VERCELAB_DATABASE_PROVIDER)"
-  existing_database_path="$(read_env_value VERCELAB_DATABASE_PATH)"
   existing_postgres_url="$(read_env_value VERCELAB_POSTGRES_URL)"
+  existing_postgres_user="$(read_env_value VERCELAB_POSTGRES_USER)"
+  existing_postgres_password="$(read_env_value VERCELAB_POSTGRES_PASSWORD)"
+  existing_postgres_db="$(read_env_value VERCELAB_POSTGRES_DB)"
+  existing_postgres_data_dir="$(read_env_value VERCELAB_POSTGRES_DATA_DIR)"
+  existing_influx_url="$(read_env_value VERCELAB_INFLUXDB_URL)"
+  existing_influx_database="$(read_env_value VERCELAB_INFLUXDB_DATABASE)"
+  existing_influx_token="$(read_env_value VERCELAB_INFLUXDB_TOKEN)"
+  existing_influx_retention_days="$(read_env_value VERCELAB_INFLUXDB_RETENTION_DAYS)"
+  existing_influx_data_dir="$(read_env_value VERCELAB_INFLUXDB_DATA_DIR)"
   existing_secret="$(read_env_value VERCELAB_ENCRYPTION_SECRET)"
   existing_github_token="$(read_env_value VERCELAB_GITHUB_TOKEN)"
 
@@ -450,13 +458,21 @@ gather_configuration() {
   VERCELAB_APPS_DIR="${VERCELAB_APPS_DIR:-${existing_apps_dir:-${VERCELAB_DATA_ROOT}/apps}}"
   VERCELAB_LOGS_DIR="${VERCELAB_LOGS_DIR:-${existing_logs_dir:-${VERCELAB_DATA_ROOT}/logs}}"
   VERCELAB_LOCKS_DIR="${VERCELAB_LOCKS_DIR:-${existing_locks_dir:-${VERCELAB_DATA_ROOT}/locks}}"
-  VERCELAB_DATABASE_PATH="${VERCELAB_DATABASE_PATH:-${existing_database_path:-${VERCELAB_DATA_ROOT}/db/vercelab.sqlite}}"
+  VERCELAB_POSTGRES_DATA_DIR="${VERCELAB_POSTGRES_DATA_DIR:-${existing_postgres_data_dir:-${VERCELAB_DATA_ROOT}/postgres}}"
+  VERCELAB_INFLUXDB_DATA_DIR="${VERCELAB_INFLUXDB_DATA_DIR:-${existing_influx_data_dir:-${VERCELAB_DATA_ROOT}/influxdb}}"
 
   VERCELAB_PROXY_NETWORK="${VERCELAB_PROXY_NETWORK:-${existing_proxy_network:-vercelab_proxy}}"
   VERCELAB_PROXY_ENTRYPOINT="${VERCELAB_PROXY_ENTRYPOINT:-${existing_proxy_entrypoint:-websecure}}"
   VERCELAB_DOCKER_SOCKET_PATH="${VERCELAB_DOCKER_SOCKET_PATH:-${existing_socket:-/var/run/docker.sock}}"
-  VERCELAB_DATABASE_PROVIDER="${VERCELAB_DATABASE_PROVIDER:-${existing_database_provider:-sqlite}}"
-  VERCELAB_POSTGRES_URL="${VERCELAB_POSTGRES_URL:-${existing_postgres_url:-}}"
+  VERCELAB_DATABASE_PROVIDER="${VERCELAB_DATABASE_PROVIDER:-${existing_database_provider:-postgres}}"
+  VERCELAB_POSTGRES_USER="${VERCELAB_POSTGRES_USER:-${existing_postgres_user:-vercelab}}"
+  VERCELAB_POSTGRES_PASSWORD="${VERCELAB_POSTGRES_PASSWORD:-${existing_postgres_password:-$(openssl rand -hex 16)}}"
+  VERCELAB_POSTGRES_DB="${VERCELAB_POSTGRES_DB:-${existing_postgres_db:-vercelab}}"
+  VERCELAB_POSTGRES_URL="${VERCELAB_POSTGRES_URL:-${existing_postgres_url:-postgres://${VERCELAB_POSTGRES_USER}:${VERCELAB_POSTGRES_PASSWORD}@postgres:5432/${VERCELAB_POSTGRES_DB}}}"
+  VERCELAB_INFLUXDB_URL="${VERCELAB_INFLUXDB_URL:-${existing_influx_url:-http://influxdb:8181}}"
+  VERCELAB_INFLUXDB_DATABASE="${VERCELAB_INFLUXDB_DATABASE:-${existing_influx_database:-vercelab_metrics}}"
+  VERCELAB_INFLUXDB_TOKEN="${VERCELAB_INFLUXDB_TOKEN:-${existing_influx_token:-}}"
+  VERCELAB_INFLUXDB_RETENTION_DAYS="${VERCELAB_INFLUXDB_RETENTION_DAYS:-${existing_influx_retention_days:-90}}"
   VERCELAB_ENCRYPTION_SECRET="${VERCELAB_ENCRYPTION_SECRET:-${existing_secret:-}}"
 
   validate_domain "$VERCELAB_BASE_DOMAIN" "VERCELAB_BASE_DOMAIN"
@@ -468,11 +484,12 @@ gather_configuration() {
   validate_absolute_path "$VERCELAB_APPS_DIR" "VERCELAB_APPS_DIR"
   validate_absolute_path "$VERCELAB_LOGS_DIR" "VERCELAB_LOGS_DIR"
   validate_absolute_path "$VERCELAB_LOCKS_DIR" "VERCELAB_LOCKS_DIR"
-  validate_absolute_path "$VERCELAB_DATABASE_PATH" "VERCELAB_DATABASE_PATH"
+  validate_absolute_path "$VERCELAB_POSTGRES_DATA_DIR" "VERCELAB_POSTGRES_DATA_DIR"
+  validate_absolute_path "$VERCELAB_INFLUXDB_DATA_DIR" "VERCELAB_INFLUXDB_DATA_DIR"
   validate_absolute_path "$VERCELAB_DOCKER_SOCKET_PATH" "VERCELAB_DOCKER_SOCKET_PATH"
 
   [[ "$VERCELAB_ADMIN_HOST" == "$VERCELAB_BASE_DOMAIN" || "$VERCELAB_ADMIN_HOST" == *".${VERCELAB_BASE_DOMAIN}" ]] || fail "VERCELAB_ADMIN_HOST must be inside VERCELAB_BASE_DOMAIN."
-  [[ "$VERCELAB_DATABASE_PROVIDER" == "sqlite" || "$VERCELAB_DATABASE_PROVIDER" == "postgres" ]] || fail "VERCELAB_DATABASE_PROVIDER must be sqlite or postgres."
+  [[ "$VERCELAB_DATABASE_PROVIDER" == "postgres" ]] || fail "VERCELAB_DATABASE_PROVIDER must be postgres."
 
   ensure_path_inside_root "$VERCELAB_DATA_ROOT" "VERCELAB_DATA_ROOT"
   ensure_path_inside_root "$VERCELAB_TRAEFIK_DYNAMIC_DIR" "VERCELAB_TRAEFIK_DYNAMIC_DIR"
@@ -480,10 +497,11 @@ gather_configuration() {
   ensure_path_inside_root "$VERCELAB_APPS_DIR" "VERCELAB_APPS_DIR"
   ensure_path_inside_root "$VERCELAB_LOGS_DIR" "VERCELAB_LOGS_DIR"
   ensure_path_inside_root "$VERCELAB_LOCKS_DIR" "VERCELAB_LOCKS_DIR"
-  ensure_path_inside_root "$VERCELAB_DATABASE_PATH" "VERCELAB_DATABASE_PATH"
+  ensure_path_inside_root "$VERCELAB_POSTGRES_DATA_DIR" "VERCELAB_POSTGRES_DATA_DIR"
+  ensure_path_inside_root "$VERCELAB_INFLUXDB_DATA_DIR" "VERCELAB_INFLUXDB_DATA_DIR"
 
-  if [[ "$VERCELAB_DATABASE_PROVIDER" == "postgres" && -z "$VERCELAB_POSTGRES_URL" ]]; then
-    fail "Set VERCELAB_POSTGRES_URL when using the postgres provider."
+  if [[ -z "$VERCELAB_POSTGRES_URL" ]]; then
+    fail "Set VERCELAB_POSTGRES_URL for the postgres provider."
   fi
 
   if [[ -z "$VERCELAB_ENCRYPTION_SECRET" ]]; then
@@ -506,7 +524,8 @@ prepare_host_directories() {
     "$VERCELAB_APPS_DIR" \
     "$VERCELAB_LOGS_DIR" \
     "$VERCELAB_LOCKS_DIR" \
-    "$(dirname "$VERCELAB_DATABASE_PATH")"
+    "$VERCELAB_POSTGRES_DATA_DIR" \
+    "$VERCELAB_INFLUXDB_DATA_DIR"
 }
 
 validate_docker_socket() {
@@ -579,11 +598,20 @@ VERCELAB_TRAEFIK_CERTS_DIR=$VERCELAB_TRAEFIK_CERTS_DIR
 VERCELAB_APPS_DIR=$VERCELAB_APPS_DIR
 VERCELAB_LOGS_DIR=$VERCELAB_LOGS_DIR
 VERCELAB_LOCKS_DIR=$VERCELAB_LOCKS_DIR
-VERCELAB_DATABASE_PATH=$VERCELAB_DATABASE_PATH
+VERCELAB_POSTGRES_DATA_DIR=$VERCELAB_POSTGRES_DATA_DIR
+VERCELAB_INFLUXDB_DATA_DIR=$VERCELAB_INFLUXDB_DATA_DIR
 VERCELAB_DOCKER_SOCKET_PATH=$VERCELAB_DOCKER_SOCKET_PATH
 
 VERCELAB_DATABASE_PROVIDER=$VERCELAB_DATABASE_PROVIDER
 VERCELAB_POSTGRES_URL=$VERCELAB_POSTGRES_URL
+VERCELAB_POSTGRES_USER=$VERCELAB_POSTGRES_USER
+VERCELAB_POSTGRES_PASSWORD=$VERCELAB_POSTGRES_PASSWORD
+VERCELAB_POSTGRES_DB=$VERCELAB_POSTGRES_DB
+
+VERCELAB_INFLUXDB_URL=$VERCELAB_INFLUXDB_URL
+VERCELAB_INFLUXDB_DATABASE=$VERCELAB_INFLUXDB_DATABASE
+VERCELAB_INFLUXDB_TOKEN=$VERCELAB_INFLUXDB_TOKEN
+VERCELAB_INFLUXDB_RETENTION_DAYS=$VERCELAB_INFLUXDB_RETENTION_DAYS
 
 VERCELAB_ENCRYPTION_SECRET=$VERCELAB_ENCRYPTION_SECRET
 VERCELAB_GITHUB_TOKEN=$VERCELAB_GITHUB_TOKEN
@@ -623,11 +651,21 @@ print_configuration_review() {
   printf '   VERCELAB_APPS_DIR        : %s\n' "$VERCELAB_APPS_DIR"
   printf '   VERCELAB_LOGS_DIR        : %s\n' "$VERCELAB_LOGS_DIR"
   printf '   VERCELAB_LOCKS_DIR       : %s\n' "$VERCELAB_LOCKS_DIR"
-  printf '   VERCELAB_DATABASE_PATH   : %s\n' "$VERCELAB_DATABASE_PATH"
+  printf '   VERCELAB_POSTGRES_DATA_DIR: %s\n' "$VERCELAB_POSTGRES_DATA_DIR"
+  printf '   VERCELAB_INFLUXDB_DATA_DIR: %s\n' "$VERCELAB_INFLUXDB_DATA_DIR"
   printf '   VERCELAB_DOCKER_SOCKET   : %s\n' "$VERCELAB_DOCKER_SOCKET_PATH"
+  printf '\n'
+  printf '%b Databases%b\n' "$C_YELLOW" "$C_RESET"
+  printf '   VERCELAB_DATABASE_PROVIDER: %s\n' "$VERCELAB_DATABASE_PROVIDER"
+  printf '   VERCELAB_POSTGRES_URL     : %s\n' "$VERCELAB_POSTGRES_URL"
+  printf '   VERCELAB_INFLUXDB_URL     : %s\n' "$VERCELAB_INFLUXDB_URL"
+  printf '   VERCELAB_INFLUXDB_DATABASE: %s\n' "$VERCELAB_INFLUXDB_DATABASE"
+  printf '   VERCELAB_INFLUXDB_RET_DAYS: %s\n' "$VERCELAB_INFLUXDB_RETENTION_DAYS"
   printf '\n'
   printf '%b Security%b\n' "$C_YELLOW" "$C_RESET"
   printf '   VERCELAB_ENCRYPTION_SECRET: %s\n' "$(mask_secret "$VERCELAB_ENCRYPTION_SECRET")"
+  printf '   VERCELAB_POSTGRES_PASSWORD: %s\n' "$(mask_secret "$VERCELAB_POSTGRES_PASSWORD")"
+  printf '   VERCELAB_INFLUXDB_TOKEN   : %s\n' "$(mask_secret "$VERCELAB_INFLUXDB_TOKEN")"
   printf '   VERCELAB_GITHUB_TOKEN     : %s\n' "$(mask_secret "$VERCELAB_GITHUB_TOKEN")"
   printf '%b============================================================%b\n' "$C_CYAN" "$C_RESET"
   printf '\n'

--- a/lib/app-config.ts
+++ b/lib/app-config.ts
@@ -7,9 +7,28 @@ const envSchema = z.object({
   NODE_ENV: z
     .enum(["development", "test", "production"])
     .default("development"),
-  VERCELAB_DATABASE_PROVIDER: z.enum(["sqlite", "postgres"]).default("sqlite"),
-  VERCELAB_DATABASE_PATH: z.string().optional(),
-  VERCELAB_POSTGRES_URL: z.string().optional(),
+  VERCELAB_DATABASE_PROVIDER: z.enum(["postgres"]).default("postgres"),
+  VERCELAB_POSTGRES_URL: z.string().trim().min(1),
+  VERCELAB_POSTGRES_USER: z.string().trim().min(1).default("vercelab"),
+  VERCELAB_POSTGRES_PASSWORD: z.string().trim().min(1).default("vercelab"),
+  VERCELAB_POSTGRES_DB: z.string().trim().min(1).default("vercelab"),
+  VERCELAB_INFLUXDB_URL: z
+    .string()
+    .trim()
+    .min(1)
+    .default("http://influxdb:8181"),
+  VERCELAB_INFLUXDB_DATABASE: z
+    .string()
+    .trim()
+    .min(1)
+    .default("vercelab_metrics"),
+  VERCELAB_INFLUXDB_TOKEN: z.string().trim().optional(),
+  VERCELAB_INFLUXDB_RETENTION_DAYS: z.coerce
+    .number()
+    .int()
+    .min(1)
+    .max(3650)
+    .default(90),
   VERCELAB_HOST_ROOT: z
     .string()
     .trim()
@@ -56,13 +75,9 @@ function buildConfig() {
   const appsDir = parsed.VERCELAB_APPS_DIR ?? path.join(dataDir, "apps");
   const logsDir = parsed.VERCELAB_LOGS_DIR ?? path.join(dataDir, "logs");
   const locksDir = parsed.VERCELAB_LOCKS_DIR ?? path.join(dataDir, "locks");
-  const sqlitePath =
-    parsed.VERCELAB_DATABASE_PATH ?? path.join(dataDir, "vercelab.sqlite");
-
   mkdirSync(appsDir, { recursive: true });
   mkdirSync(logsDir, { recursive: true });
   mkdirSync(locksDir, { recursive: true });
-  mkdirSync(path.dirname(sqlitePath), { recursive: true });
 
   return {
     env: parsed.NODE_ENV,
@@ -78,8 +93,16 @@ function buildConfig() {
     },
     database: {
       provider: parsed.VERCELAB_DATABASE_PROVIDER,
-      sqlitePath,
       postgresUrl: parsed.VERCELAB_POSTGRES_URL,
+      postgresUser: parsed.VERCELAB_POSTGRES_USER,
+      postgresPassword: parsed.VERCELAB_POSTGRES_PASSWORD,
+      postgresDatabase: parsed.VERCELAB_POSTGRES_DB,
+    },
+    metrics: {
+      influxUrl: parsed.VERCELAB_INFLUXDB_URL,
+      influxDatabase: parsed.VERCELAB_INFLUXDB_DATABASE,
+      influxToken: parsed.VERCELAB_INFLUXDB_TOKEN ?? null,
+      retentionDays: parsed.VERCELAB_INFLUXDB_RETENTION_DAYS,
     },
     security: {
       encryptionSecret: parsed.VERCELAB_ENCRYPTION_SECRET,

--- a/lib/deployment-engine.ts
+++ b/lib/deployment-engine.ts
@@ -309,7 +309,7 @@ async function cloneRepository(deployment: StoredDeployment) {
 
   const cloneUrl = buildGitCloneUrl(
     deployment.repositoryUrl,
-    readDeploymentSecretToken(deployment.id),
+    await readDeploymentSecretToken(deployment.id),
   );
 
   const args = ["clone", "--depth", "1"];
@@ -334,7 +334,7 @@ async function deployWorkspace(
   const cloneOutput = shouldClone ? await cloneRepository(deployment) : "";
   const runtimeFiles = await detectRuntimeFiles(deployment);
 
-  updateDeploymentRecord(deployment.id, {
+  await updateDeploymentRecord(deployment.id, {
     composeMode: runtimeFiles.composeMode,
     composeFile: runtimeFiles.composeFile,
     serviceName: runtimeFiles.serviceName,
@@ -587,14 +587,14 @@ async function executeLifecycleOperation(
   statusOnSuccess: StoredDeployment["status"],
 ) {
   return await withDeploymentLock(async () => {
-    const deployment = getStoredDeploymentById(deploymentId);
-    const operationId = createOperation(
+    const deployment = await getStoredDeploymentById(deploymentId);
+    const operationId = await createOperation(
       deploymentId,
       operationType,
       `${operationType} started for ${deployment.appName}`,
     );
 
-    updateDeploymentRecord(deploymentId, {
+    await updateDeploymentRecord(deploymentId, {
       status:
         operationType === "remove"
           ? "removing"
@@ -612,10 +612,10 @@ async function executeLifecycleOperation(
             ? `Removed ${deployment.appName}.`
             : `Deployment is live at https://${getDefaultDomain(deployment.subdomain)}.`;
 
-      completeOperation(operationId, "success", summary, output);
+      await completeOperation(operationId, "success", summary, output);
 
       if (operationType !== "remove") {
-        updateDeploymentRecord(deploymentId, {
+        await updateDeploymentRecord(deploymentId, {
           status: statusOnSuccess,
           lastOutput: output,
           deployedAt:
@@ -635,8 +635,8 @@ async function executeLifecycleOperation(
           ? error.message
           : "Unexpected deployment failure.";
 
-      completeOperation(operationId, "failed", message, message);
-      updateDeploymentRecord(deploymentId, {
+      await completeOperation(operationId, "failed", message, message);
+      await updateDeploymentRecord(deploymentId, {
         status: operationType === "stop" ? "failed" : "failed",
         lastOutput: message,
       });
@@ -666,7 +666,7 @@ export async function createAndDeployFromForm(input: {
     envVariables: normalizeStringInput(input.envVariables),
   });
 
-  const { deploymentId, domain } = createDeploymentRecord(parsed);
+  const { deploymentId, domain } = await createDeploymentRecord(parsed);
   await fetchDeploymentFromGitById(deploymentId, "deploy");
 
   return {
@@ -714,7 +714,7 @@ export async function updateDeploymentSettingsById(input: {
   });
 
   try {
-    updateDeploymentRecord(parsed.deploymentId, {
+    await updateDeploymentRecord(parsed.deploymentId, {
       appName: parsed.appName,
       subdomain: parsed.subdomain,
       port: parsed.port,
@@ -753,7 +753,7 @@ export async function stopDeploymentById(deploymentId: string) {
         "--remove-orphans",
       ]);
 
-      updateDeploymentRecord(deployment.id, {
+      await updateDeploymentRecord(deployment.id, {
         status: "stopped",
         lastOutput: output,
       });
@@ -766,14 +766,14 @@ export async function stopDeploymentById(deploymentId: string) {
 
 export async function removeDeploymentById(deploymentId: string) {
   return await withDeploymentLock(async () => {
-    const deployment = getStoredDeploymentById(deploymentId);
-    const operationId = createOperation(
+    const deployment = await getStoredDeploymentById(deploymentId);
+    const operationId = await createOperation(
       deploymentId,
       "remove",
       `remove started for ${deployment.appName}`,
     );
 
-    updateDeploymentRecord(deploymentId, {
+    await updateDeploymentRecord(deploymentId, {
       status: "removing",
     });
 
@@ -796,13 +796,13 @@ export async function removeDeploymentById(deploymentId: string) {
       }
 
       await removeWorkspace(deployment.workspacePath);
-      completeOperation(
+      await completeOperation(
         operationId,
         "success",
         `Removed ${deployment.appName}.`,
         truncateOutput(output),
       );
-      deleteDeploymentRecord(deploymentId);
+      await deleteDeploymentRecord(deploymentId);
 
       return {
         appName: deployment.appName,
@@ -810,8 +810,8 @@ export async function removeDeploymentById(deploymentId: string) {
     } catch (error) {
       const message =
         error instanceof Error ? error.message : "Unexpected removal failure.";
-      completeOperation(operationId, "failed", message, message);
-      updateDeploymentRecord(deploymentId, {
+      await completeOperation(operationId, "failed", message, message);
+      await updateDeploymentRecord(deploymentId, {
         status: "failed",
         lastOutput: message,
       });
@@ -820,9 +820,9 @@ export async function removeDeploymentById(deploymentId: string) {
   });
 }
 
-export function readDeploymentBuildLog(deploymentId: string) {
-  const deployment = getStoredDeploymentById(deploymentId);
-  const operation = getLatestDeploymentOperation(deploymentId);
+export async function readDeploymentBuildLog(deploymentId: string) {
+  const deployment = await getStoredDeploymentById(deploymentId);
+  const operation = await getLatestDeploymentOperation(deploymentId);
 
   return {
     type: "build" as const,
@@ -842,7 +842,7 @@ export function readDeploymentBuildLog(deploymentId: string) {
 }
 
 export async function readDeploymentContainerLog(deploymentId: string) {
-  const deployment = getStoredDeploymentById(deploymentId);
+  const deployment = await getStoredDeploymentById(deploymentId);
 
   if (!(await pathExists(deployment.workspacePath))) {
     return {

--- a/lib/persistence.ts
+++ b/lib/persistence.ts
@@ -1,6 +1,6 @@
 import path from "node:path";
 
-import Database from "better-sqlite3";
+import { Pool, type PoolClient } from "pg";
 
 import { getAppConfig } from "@/lib/app-config";
 import { decryptSecret, encryptSecret } from "@/lib/crypto";
@@ -15,8 +15,6 @@ export type DeploymentStatus =
 export type DeploymentMode = "dockerfile" | "compose" | null;
 export type OperationType = "deploy" | "redeploy" | "stop" | "remove";
 export type OperationStatus = "pending" | "success" | "failed";
-
-type DatabaseHandle = Database.Database;
 
 export type StoredDeployment = {
   id: string;
@@ -153,7 +151,7 @@ type DashboardDeploymentRow = {
   last_operation_summary: string | null;
   updated_at: string;
   deployed_at: string | null;
-  token_stored: number;
+  token_stored: boolean;
 };
 
 type DeploymentOperationRow = {
@@ -180,7 +178,8 @@ type DashboardTrendRow = {
   created_at: string;
 };
 
-let database: DatabaseHandle | undefined;
+let pool: Pool | undefined;
+let initPromise: Promise<void> | undefined;
 const trendLabelFormatter = new Intl.DateTimeFormat("en", { weekday: "short" });
 
 function toSlug(value: string): string {
@@ -198,6 +197,15 @@ function serializeOutput(value: string | null): string | null {
   }
 
   return value.slice(-12000);
+}
+
+function isUniqueViolation(error: unknown) {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    (error as { code?: string }).code === "23505"
+  );
 }
 
 function mapStoredDeployment(row: StoredDeploymentRow): StoredDeployment {
@@ -274,173 +282,195 @@ function buildTrendPoints(
   }));
 }
 
-function getDatabase(): DatabaseHandle {
-  const config = getAppConfig();
-
-  if (config.database.provider !== "sqlite") {
-    throw new Error(
-      "Postgres provider is planned but not implemented yet. Use SQLite for this MVP build.",
-    );
+function getPool() {
+  if (!pool) {
+    const config = getAppConfig();
+    pool = new Pool({
+      connectionString: config.database.postgresUrl,
+      max: 20,
+    });
   }
 
-  if (!database) {
-    database = new Database(config.database.sqlitePath);
-    database.pragma("journal_mode = WAL");
-    database.pragma("foreign_keys = ON");
-    initDatabase(database);
-  }
-
-  return database;
+  return pool;
 }
 
-function initDatabase(db: DatabaseHandle) {
-  db.exec(`
-    CREATE TABLE IF NOT EXISTS repositories (
-      id TEXT PRIMARY KEY,
-      name TEXT NOT NULL,
-      repository_url TEXT NOT NULL,
-      encrypted_token TEXT,
-      branch TEXT,
-      created_at TEXT NOT NULL,
-      updated_at TEXT NOT NULL
-    );
+async function initDatabase() {
+  if (!initPromise) {
+    initPromise = (async () => {
+      const client = await getPool().connect();
 
-    CREATE TABLE IF NOT EXISTS deployments (
-      id TEXT PRIMARY KEY,
-      repository_id TEXT NOT NULL REFERENCES repositories(id) ON DELETE CASCADE,
-      app_name TEXT NOT NULL,
-      app_slug TEXT NOT NULL,
-      subdomain TEXT NOT NULL UNIQUE,
-      port INTEGER NOT NULL,
-      env_variables TEXT,
-      service_name TEXT,
-      status TEXT NOT NULL,
-      compose_mode TEXT,
-      compose_file TEXT,
-      project_name TEXT NOT NULL UNIQUE,
-      workspace_path TEXT NOT NULL,
-      last_output TEXT,
-      created_at TEXT NOT NULL,
-      updated_at TEXT NOT NULL,
-      deployed_at TEXT
-    );
+      try {
+        await client.query(`
+          CREATE TABLE IF NOT EXISTS repositories (
+            id TEXT PRIMARY KEY,
+            name TEXT NOT NULL,
+            repository_url TEXT NOT NULL,
+            encrypted_token TEXT,
+            branch TEXT,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL
+          );
 
-    CREATE TABLE IF NOT EXISTS operations (
-      id TEXT PRIMARY KEY,
-      deployment_id TEXT NOT NULL REFERENCES deployments(id) ON DELETE CASCADE,
-      operation_type TEXT NOT NULL,
-      status TEXT NOT NULL,
-      summary TEXT,
-      output TEXT,
-      created_at TEXT NOT NULL,
-      updated_at TEXT NOT NULL
-    );
+          CREATE TABLE IF NOT EXISTS deployments (
+            id TEXT PRIMARY KEY,
+            repository_id TEXT NOT NULL REFERENCES repositories(id) ON DELETE CASCADE,
+            app_name TEXT NOT NULL,
+            app_slug TEXT NOT NULL,
+            subdomain TEXT NOT NULL UNIQUE,
+            port INTEGER NOT NULL,
+            env_variables TEXT,
+            service_name TEXT,
+            status TEXT NOT NULL,
+            compose_mode TEXT,
+            compose_file TEXT,
+            project_name TEXT NOT NULL UNIQUE,
+            workspace_path TEXT NOT NULL,
+            last_output TEXT,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL,
+            deployed_at TEXT
+          );
 
-    CREATE INDEX IF NOT EXISTS idx_deployments_repository_id ON deployments(repository_id);
-    CREATE INDEX IF NOT EXISTS idx_operations_deployment_id ON operations(deployment_id);
-    CREATE INDEX IF NOT EXISTS idx_operations_created_at ON operations(created_at DESC);
-  `);
+          CREATE TABLE IF NOT EXISTS operations (
+            id TEXT PRIMARY KEY,
+            deployment_id TEXT NOT NULL REFERENCES deployments(id) ON DELETE CASCADE,
+            operation_type TEXT NOT NULL,
+            status TEXT NOT NULL,
+            summary TEXT,
+            output TEXT,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL
+          );
 
-  const deploymentColumns = db
-    .prepare("PRAGMA table_info(deployments)")
-    .all() as Array<{ name: string }>;
-  const hasEnvVariablesColumn = deploymentColumns.some(
-    (column) => column.name === "env_variables",
+          CREATE INDEX IF NOT EXISTS idx_deployments_repository_id ON deployments(repository_id);
+          CREATE INDEX IF NOT EXISTS idx_operations_deployment_id ON operations(deployment_id);
+          CREATE INDEX IF NOT EXISTS idx_operations_created_at ON operations(created_at DESC);
+        `);
+      } finally {
+        client.release();
+      }
+    })();
+  }
+
+  await initPromise;
+}
+
+async function queryRows<T>(
+  statement: string,
+  values: unknown[] = [],
+  client?: PoolClient,
+): Promise<T[]> {
+  await initDatabase();
+  const result = client
+    ? await client.query(statement, values)
+    : await getPool().query(statement, values);
+
+  return result.rows as T[];
+}
+
+async function withTransaction<T>(task: (client: PoolClient) => Promise<T>) {
+  await initDatabase();
+  const client = await getPool().connect();
+
+  try {
+    await client.query("BEGIN");
+    const result = await task(client);
+    await client.query("COMMIT");
+    return result;
+  } catch (error) {
+    await client.query("ROLLBACK");
+    throw error;
+  } finally {
+    client.release();
+  }
+}
+
+export async function getDatabaseHealth() {
+  const config = getAppConfig();
+  await initDatabase();
+  const rows = await queryRows<{ version: string }>(
+    "SELECT version() AS version",
   );
-
-  if (!hasEnvVariablesColumn) {
-    db.exec("ALTER TABLE deployments ADD COLUMN env_variables TEXT");
-  }
-}
-
-export function getDatabaseHealth() {
-  const config = getAppConfig();
-  const db = getDatabase();
-  const result = db.prepare("SELECT sqlite_version() AS version").get() as {
-    version: string;
-  };
 
   return {
     provider: config.database.provider,
-    sqlitePath: config.database.sqlitePath,
-    version: result.version,
+    postgresUrl: config.database.postgresUrl,
+    version: rows[0]?.version ?? "unknown",
   };
 }
 
-export function listDashboardData(): DashboardData {
-  const db = getDatabase();
-  const rows = db
-    .prepare(
-      `
-        SELECT
-          d.id,
-          r.name AS repository_name,
-          r.repository_url,
-          r.branch,
-          d.app_name,
-          d.subdomain,
-          d.port,
-          d.env_variables,
-          d.service_name,
-          d.status,
-          d.compose_mode,
-          d.project_name,
-          d.last_output,
-          d.updated_at,
-          d.deployed_at,
-          CASE WHEN r.encrypted_token IS NULL THEN 0 ELSE 1 END AS token_stored,
-          (
-            SELECT summary
-            FROM operations o
-            WHERE o.deployment_id = d.id
-            ORDER BY o.created_at DESC
-            LIMIT 1
-          ) AS last_operation_summary
-        FROM deployments d
-        INNER JOIN repositories r ON r.id = d.repository_id
-        ORDER BY d.updated_at DESC
-      `,
-    )
-    .all() as DashboardDeploymentRow[];
+export async function listDashboardData(): Promise<DashboardData> {
+  const rows = await queryRows<DashboardDeploymentRow>(
+    `
+      SELECT
+        d.id,
+        r.name AS repository_name,
+        r.repository_url,
+        r.branch,
+        d.app_name,
+        d.subdomain,
+        d.port,
+        d.env_variables,
+        d.service_name,
+        d.status,
+        d.compose_mode,
+        d.project_name,
+        d.last_output,
+        d.updated_at,
+        d.deployed_at,
+        (r.encrypted_token IS NOT NULL) AS token_stored,
+        (
+          SELECT summary
+          FROM operations o
+          WHERE o.deployment_id = d.id
+          ORDER BY o.created_at DESC
+          LIMIT 1
+        ) AS last_operation_summary
+      FROM deployments d
+      INNER JOIN repositories r ON r.id = d.repository_id
+      ORDER BY d.updated_at DESC
+    `,
+  );
 
-  const activityRows = db
-    .prepare(
-      `
-        SELECT
-          o.id,
-          d.app_name,
-          o.operation_type,
-          o.status,
-          o.summary,
-          o.created_at
-        FROM operations o
-        INNER JOIN deployments d ON d.id = o.deployment_id
-        ORDER BY o.created_at DESC
-        LIMIT 7
-      `,
-    )
-    .all() as DashboardActivityRow[];
+  const activityRows = await queryRows<DashboardActivityRow>(
+    `
+      SELECT
+        o.id,
+        d.app_name,
+        o.operation_type,
+        o.status,
+        o.summary,
+        o.created_at
+      FROM operations o
+      INNER JOIN deployments d ON d.id = o.deployment_id
+      ORDER BY o.created_at DESC
+      LIMIT 7
+    `,
+  );
 
   const sinceDate = new Date();
   sinceDate.setHours(0, 0, 0, 0);
   sinceDate.setDate(sinceDate.getDate() - 7);
 
-  const trendRows = db
-    .prepare(
-      `
-        SELECT
-          status,
-          created_at
-        FROM operations
-        WHERE created_at >= ?
-        ORDER BY created_at ASC
-      `,
-    )
-    .all(sinceDate.toISOString()) as DashboardTrendRow[];
+  const trendRows = await queryRows<DashboardTrendRow>(
+    `
+      SELECT
+        status,
+        created_at
+      FROM operations
+      WHERE created_at >= $1
+      ORDER BY created_at ASC
+    `,
+    [sinceDate.toISOString()],
+  );
 
-  const repositoryCount = db
-    .prepare("SELECT COUNT(*) AS count FROM repositories")
-    .get() as { count: number };
+  const repositoryCountRows = await queryRows<{ count: string }>(
+    "SELECT COUNT(*) AS count FROM repositories",
+  );
+  const repositoryCount = Number.parseInt(
+    repositoryCountRows[0]?.count ?? "0",
+    10,
+  );
 
   const stats = rows.reduce(
     (accumulator, deployment) => {
@@ -498,13 +528,13 @@ export function listDashboardData(): DashboardData {
       lastOperationSummary: row.last_operation_summary,
       updatedAt: row.updated_at,
       deployedAt: row.deployed_at,
-      tokenStored: row.token_stored === 1,
+      tokenStored: row.token_stored,
     })),
     stats: {
       totalDeployments: stats.totalDeployments,
       runningDeployments: stats.runningDeployments,
       failedDeployments: stats.failedDeployments,
-      totalRepositories: repositoryCount.count,
+      totalRepositories: Number.isFinite(repositoryCount) ? repositoryCount : 0,
     },
     trends: buildTrendPoints(trendRows),
     recentActivity: activityRows.map((row) => ({
@@ -520,8 +550,7 @@ export function listDashboardData(): DashboardData {
   };
 }
 
-export function createDeploymentRecord(input: CreateDeploymentInput) {
-  const db = getDatabase();
+export async function createDeploymentRecord(input: CreateDeploymentInput) {
   const now = new Date().toISOString();
   const repositoryId = crypto.randomUUID();
   const deploymentId = crypto.randomUUID();
@@ -534,76 +563,78 @@ export function createDeploymentRecord(input: CreateDeploymentInput) {
   const workspacePath = path.join(getAppConfig().paths.appsDir, deploymentId);
   const projectName = `vercelab-${appSlug}-${deploymentId.slice(0, 8)}`;
 
-  const transaction = db.transaction(() => {
-    db.prepare(
-      `
-        INSERT INTO repositories (
-          id,
-          name,
-          repository_url,
-          encrypted_token,
-          branch,
-          created_at,
-          updated_at
-        ) VALUES (?, ?, ?, ?, ?, ?, ?)
-      `,
-    ).run(
-      repositoryId,
-      repoName,
-      input.repositoryUrl,
-      input.githubToken ? encryptSecret(input.githubToken) : null,
-      input.branch ?? null,
-      now,
-      now,
-    );
-
-    db.prepare(
-      `
-        INSERT INTO deployments (
-          id,
-          repository_id,
-          app_name,
-          app_slug,
-          subdomain,
-          port,
-          env_variables,
-          service_name,
-          status,
-          compose_mode,
-          compose_file,
-          project_name,
-          workspace_path,
-          last_output,
-          created_at,
-          updated_at,
-          deployed_at
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-      `,
-    ).run(
-      deploymentId,
-      repositoryId,
-      input.appName,
-      appSlug,
-      input.subdomain,
-      input.port,
-      input.envVariables ?? null,
-      input.serviceName ?? null,
-      "deploying",
-      null,
-      null,
-      projectName,
-      workspacePath,
-      null,
-      now,
-      now,
-      null,
-    );
-  });
-
   try {
-    transaction();
+    await withTransaction(async (client) => {
+      await queryRows(
+        `
+          INSERT INTO repositories (
+            id,
+            name,
+            repository_url,
+            encrypted_token,
+            branch,
+            created_at,
+            updated_at
+          ) VALUES ($1, $2, $3, $4, $5, $6, $7)
+        `,
+        [
+          repositoryId,
+          repoName,
+          input.repositoryUrl,
+          input.githubToken ? encryptSecret(input.githubToken) : null,
+          input.branch ?? null,
+          now,
+          now,
+        ],
+        client,
+      );
+
+      await queryRows(
+        `
+          INSERT INTO deployments (
+            id,
+            repository_id,
+            app_name,
+            app_slug,
+            subdomain,
+            port,
+            env_variables,
+            service_name,
+            status,
+            compose_mode,
+            compose_file,
+            project_name,
+            workspace_path,
+            last_output,
+            created_at,
+            updated_at,
+            deployed_at
+          ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)
+        `,
+        [
+          deploymentId,
+          repositoryId,
+          input.appName,
+          appSlug,
+          input.subdomain,
+          input.port,
+          input.envVariables ?? null,
+          input.serviceName ?? null,
+          "deploying",
+          null,
+          null,
+          projectName,
+          workspacePath,
+          null,
+          now,
+          now,
+          null,
+        ],
+        client,
+      );
+    });
   } catch (error) {
-    if (error instanceof Error && error.message.includes("UNIQUE")) {
+    if (isUniqueViolation(error)) {
       throw new Error(
         "That subdomain is already reserved by another deployment.",
       );
@@ -619,41 +650,41 @@ export function createDeploymentRecord(input: CreateDeploymentInput) {
   };
 }
 
-export function getStoredDeploymentById(
+export async function getStoredDeploymentById(
   deploymentId: string,
-): StoredDeployment {
-  const db = getDatabase();
-  const row = db
-    .prepare(
-      `
-        SELECT
-          d.id,
-          d.repository_id,
-          r.name AS repository_name,
-          r.repository_url,
-          r.encrypted_token,
-          r.branch,
-          d.app_name,
-          d.app_slug,
-          d.subdomain,
-          d.port,
-          d.env_variables,
-          d.service_name,
-          d.status,
-          d.compose_mode,
-          d.compose_file,
-          d.project_name,
-          d.workspace_path,
-          d.last_output,
-          d.created_at,
-          d.updated_at,
-          d.deployed_at
-        FROM deployments d
-        INNER JOIN repositories r ON r.id = d.repository_id
-        WHERE d.id = ?
-      `,
-    )
-    .get(deploymentId) as StoredDeploymentRow | undefined;
+): Promise<StoredDeployment> {
+  const rows = await queryRows<StoredDeploymentRow>(
+    `
+      SELECT
+        d.id,
+        d.repository_id,
+        r.name AS repository_name,
+        r.repository_url,
+        r.encrypted_token,
+        r.branch,
+        d.app_name,
+        d.app_slug,
+        d.subdomain,
+        d.port,
+        d.env_variables,
+        d.service_name,
+        d.status,
+        d.compose_mode,
+        d.compose_file,
+        d.project_name,
+        d.workspace_path,
+        d.last_output,
+        d.created_at,
+        d.updated_at,
+        d.deployed_at
+      FROM deployments d
+      INNER JOIN repositories r ON r.id = d.repository_id
+      WHERE d.id = $1
+    `,
+    [deploymentId],
+  );
+
+  const row = rows[0];
 
   if (!row) {
     throw new Error("Deployment not found.");
@@ -662,32 +693,36 @@ export function getStoredDeploymentById(
   return mapStoredDeployment(row);
 }
 
-export function readDeploymentSecretToken(deploymentId: string): string | null {
-  return decryptSecret(getStoredDeploymentById(deploymentId).encryptedToken);
+export async function readDeploymentSecretToken(
+  deploymentId: string,
+): Promise<string | null> {
+  return decryptSecret(
+    (await getStoredDeploymentById(deploymentId)).encryptedToken,
+  );
 }
 
-export function getLatestDeploymentOperation(
+export async function getLatestDeploymentOperation(
   deploymentId: string,
-): DeploymentOperationLog | null {
-  const db = getDatabase();
-  const row = db
-    .prepare(
-      `
-        SELECT
-          id,
-          operation_type,
-          status,
-          summary,
-          output,
-          created_at,
-          updated_at
-        FROM operations
-        WHERE deployment_id = ?
-        ORDER BY created_at DESC
-        LIMIT 1
-      `,
-    )
-    .get(deploymentId) as DeploymentOperationRow | undefined;
+): Promise<DeploymentOperationLog | null> {
+  const rows = await queryRows<DeploymentOperationRow>(
+    `
+      SELECT
+        id,
+        operation_type,
+        status,
+        summary,
+        output,
+        created_at,
+        updated_at
+      FROM operations
+      WHERE deployment_id = $1
+      ORDER BY created_at DESC
+      LIMIT 1
+    `,
+    [deploymentId],
+  );
+
+  const row = rows[0];
 
   if (!row) {
     return null;
@@ -720,11 +755,10 @@ type DeploymentUpdate = Partial<{
   deployedAt: string | null;
 }>;
 
-export function updateDeploymentRecord(
+export async function updateDeploymentRecord(
   deploymentId: string,
   update: DeploymentUpdate,
 ) {
-  const db = getDatabase();
   const entries = Object.entries(update).filter(
     ([, value]) => value !== undefined,
   );
@@ -749,35 +783,32 @@ export function updateDeploymentRecord(
     deployedAt: "deployed_at",
   };
 
-  const statement = entries
-    .map(([key]) => `${columnMap[key]} = @${key}`)
-    .concat("updated_at = @updatedAt")
-    .join(", ");
+  const values = entries.map(([key, value]) =>
+    key === "lastOutput" ? serializeOutput(value as string | null) : value,
+  );
+  const assignments = entries.map(
+    ([key], index) => `${columnMap[key]} = $${index + 1}`,
+  );
 
-  db.prepare(
-    `UPDATE deployments SET ${statement} WHERE id = @deploymentId`,
-  ).run({
-    deploymentId,
-    updatedAt: new Date().toISOString(),
-    ...Object.fromEntries(
-      entries.map(([key, value]) => [
-        key,
-        key === "lastOutput" ? serializeOutput(value as string | null) : value,
-      ]),
-    ),
-  });
+  values.push(new Date().toISOString());
+  assignments.push(`updated_at = $${values.length}`);
+  values.push(deploymentId);
+
+  await queryRows(
+    `UPDATE deployments SET ${assignments.join(", ")} WHERE id = $${values.length}`,
+    values,
+  );
 }
 
-export function createOperation(
+export async function createOperation(
   deploymentId: string,
   operationType: OperationType,
   summary: string,
 ) {
-  const db = getDatabase();
   const id = crypto.randomUUID();
   const now = new Date().toISOString();
 
-  db.prepare(
+  await queryRows(
     `
       INSERT INTO operations (
         id,
@@ -788,50 +819,66 @@ export function createOperation(
         output,
         created_at,
         updated_at
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+      ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
     `,
-  ).run(id, deploymentId, operationType, "pending", summary, null, now, now);
+    [id, deploymentId, operationType, "pending", summary, null, now, now],
+  );
 
   return id;
 }
 
-export function completeOperation(
+export async function completeOperation(
   operationId: string,
   status: OperationStatus,
   summary: string,
   output: string | null,
 ) {
-  const db = getDatabase();
   const now = new Date().toISOString();
 
-  db.prepare(
+  await queryRows(
     `
       UPDATE operations
-      SET status = ?, summary = ?, output = ?, updated_at = ?
-      WHERE id = ?
+      SET status = $1, summary = $2, output = $3, updated_at = $4
+      WHERE id = $5
     `,
-  ).run(status, summary, serializeOutput(output), now, operationId);
+    [status, summary, serializeOutput(output), now, operationId],
+  );
 }
 
-export function deleteDeploymentRecord(deploymentId: string) {
-  const db = getDatabase();
-  const deployment = getStoredDeploymentById(deploymentId);
+export async function deleteDeploymentRecord(deploymentId: string) {
+  await withTransaction(async (client) => {
+    const deploymentRows = await queryRows<{ repository_id: string }>(
+      "SELECT repository_id FROM deployments WHERE id = $1",
+      [deploymentId],
+      client,
+    );
 
-  const transaction = db.transaction(() => {
-    db.prepare("DELETE FROM deployments WHERE id = ?").run(deploymentId);
+    const deployment = deploymentRows[0];
 
-    const remaining = db
-      .prepare(
-        "SELECT COUNT(*) AS count FROM deployments WHERE repository_id = ?",
-      )
-      .get(deployment.repositoryId) as { count: number };
+    if (!deployment) {
+      throw new Error("Deployment not found.");
+    }
 
-    if (remaining.count === 0) {
-      db.prepare("DELETE FROM repositories WHERE id = ?").run(
-        deployment.repositoryId,
+    await queryRows(
+      "DELETE FROM deployments WHERE id = $1",
+      [deploymentId],
+      client,
+    );
+
+    const remainingRows = await queryRows<{ count: string }>(
+      "SELECT COUNT(*) AS count FROM deployments WHERE repository_id = $1",
+      [deployment.repository_id],
+      client,
+    );
+
+    const remaining = Number.parseInt(remainingRows[0]?.count ?? "0", 10);
+
+    if (remaining === 0) {
+      await queryRows(
+        "DELETE FROM repositories WHERE id = $1",
+        [deployment.repository_id],
+        client,
       );
     }
   });
-
-  transaction();
 }

--- a/lib/platform-health.ts
+++ b/lib/platform-health.ts
@@ -135,7 +135,6 @@ export async function getPlatformHealth(): Promise<PlatformHealth> {
       config.paths.appsDir,
       config.paths.logsDir,
       config.paths.locksDir,
-      path.dirname(config.database.sqlitePath),
     ];
     const aligned = managedPaths.every((managedPath) =>
       isWithinRoot(managedPath, config.paths.hostRoot!),
@@ -156,11 +155,18 @@ export async function getPlatformHealth(): Promise<PlatformHealth> {
     await checkWritablePath("Apps directory", config.paths.appsDir),
     await checkWritablePath("Logs directory", config.paths.logsDir),
     await checkWritablePath("Locks directory", config.paths.locksDir),
-    await checkWritablePath(
-      "Database directory",
-      path.dirname(config.database.sqlitePath),
-    ),
   );
+
+  checks.push({
+    id: "postgres-url",
+    label: "Postgres connection URL",
+    ok: config.database.postgresUrl.trim().length > 0,
+    severity: runtimeSeverity,
+    message:
+      config.database.postgresUrl.trim().length > 0
+        ? "Postgres connection URL is configured."
+        : "VERCELAB_POSTGRES_URL is not configured.",
+  });
 
   try {
     const socketStats = await stat(config.runtime.dockerSocketPath);

--- a/lib/system-metrics.ts
+++ b/lib/system-metrics.ts
@@ -63,6 +63,66 @@ let cachedSnapshot: SampleState<MetricsSnapshot> | null = null;
 let lastCpuCounters: SampleState<CpuCounters> | null = null;
 let lastNetworkCounters: SampleState<InterfaceCounters[]> | null = null;
 
+function escapeLineProtocol(value: string) {
+  return value.replace(/([ ,=])/g, "\\$1");
+}
+
+function encodeLineProtocol(snapshot: MetricsSnapshot) {
+  const timestampMs = Date.parse(snapshot.timestamp);
+  const safeTimestamp = Number.isFinite(timestampMs) ? timestampMs : Date.now();
+  const hostTag = escapeLineProtocol(snapshot.hostIp || "unknown");
+  const lines: string[] = [
+    `host_metrics,host=${hostTag} cpu_percent=${snapshot.system.cpuPercent},memory_percent=${snapshot.system.memoryPercent},memory_used_bytes=${snapshot.system.memoryUsedBytes},memory_total_bytes=${snapshot.system.memoryTotalBytes},load_1=${snapshot.system.loadAverage[0]},load_5=${snapshot.system.loadAverage[1]},load_15=${snapshot.system.loadAverage[2]},network_rx_bps=${snapshot.network.rxBytesPerSecond},network_tx_bps=${snapshot.network.txBytesPerSecond} ${safeTimestamp}`,
+    `container_metrics,host=${hostTag},scope=aggregate running=${snapshot.containers.running}i,cpu_percent=${snapshot.containers.cpuPercent},memory_percent=${snapshot.containers.memoryPercent},memory_used_bytes=${snapshot.containers.memoryUsedBytes} ${safeTimestamp}`,
+  ];
+
+  for (const iface of snapshot.network.interfaces) {
+    const ifaceTag = escapeLineProtocol(iface.name);
+    lines.push(
+      `network_interface,host=${hostTag},interface=${ifaceTag} rx_bps=${iface.rxBytesPerSecond},tx_bps=${iface.txBytesPerSecond} ${safeTimestamp}`,
+    );
+  }
+
+  for (const container of snapshot.containers.top) {
+    const containerTag = escapeLineProtocol(container.name);
+    lines.push(
+      `container_metrics,host=${hostTag},scope=top,container=${containerTag} cpu_percent=${container.cpuPercent},memory_used_bytes=${container.memoryBytes} ${safeTimestamp}`,
+    );
+  }
+
+  return lines.join("\n");
+}
+
+async function writeSnapshotToInflux(snapshot: MetricsSnapshot) {
+  const config = getAppConfig();
+
+  if (!config.metrics.influxUrl || !config.metrics.influxDatabase) {
+    return;
+  }
+
+  const writeUrl = new URL("/write", config.metrics.influxUrl);
+  writeUrl.searchParams.set("db", config.metrics.influxDatabase);
+  writeUrl.searchParams.set("precision", "ms");
+
+  const headers: Record<string, string> = {
+    "Content-Type": "text/plain; charset=utf-8",
+  };
+
+  if (config.metrics.influxToken) {
+    headers.Authorization = `Token ${config.metrics.influxToken}`;
+  }
+
+  const response = await fetch(writeUrl, {
+    method: "POST",
+    headers,
+    body: encodeLineProtocol(snapshot),
+  });
+
+  if (!response.ok) {
+    throw new Error(`InfluxDB write failed with ${response.status}.`);
+  }
+}
+
 function clamp(value: number, min: number, max: number) {
   return Math.min(max, Math.max(min, value));
 }
@@ -621,6 +681,15 @@ export async function getMetricsSnapshot() {
     capturedAt: now,
     value: snapshot,
   };
+
+  void writeSnapshotToInflux(snapshot).catch((error) => {
+    const message =
+      error instanceof Error
+        ? error.message
+        : "Unable to write metrics to InfluxDB.";
+
+    console.error(`[metrics] ${message}`);
+  });
 
   return snapshot;
 }

--- a/next.config.ts
+++ b/next.config.ts
@@ -2,7 +2,7 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   output: "standalone",
-  serverExternalPackages: ["better-sqlite3"],
+  serverExternalPackages: ["pg"],
   allowedDevOrigins: ["10.10.0.86"],
 };
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "packageManager": "pnpm@10.33.0",
   "pnpm": {
     "onlyBuiltDependencies": [
-      "better-sqlite3",
       "sharp",
       "unrs-resolver"
     ]
@@ -18,9 +17,8 @@
   },
   "dependencies": {
     "@derpdaderp/chartkit": "^0.4.1",
-    "@types/better-sqlite3": "^7.6.13",
-    "better-sqlite3": "^12.9.0",
     "next": "16.2.3",
+    "pg": "^8.16.3",
     "react": "19.2.4",
     "react-dom": "19.2.4",
     "yaml": "^2.8.3",
@@ -29,6 +27,7 @@
   "devDependencies": {
     "@tailwindcss/postcss": "^4.2.2",
     "@types/node": "^20.19.39",
+    "@types/pg": "^8.15.6",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "eslint": "^9.39.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,15 +11,12 @@ importers:
       '@derpdaderp/chartkit':
         specifier: ^0.4.1
         version: 0.4.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@types/better-sqlite3':
-        specifier: ^7.6.13
-        version: 7.6.13
-      better-sqlite3:
-        specifier: ^12.9.0
-        version: 12.9.0
       next:
         specifier: 16.2.3
         version: 16.2.3(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      pg:
+        specifier: ^8.16.3
+        version: 8.20.0
       react:
         specifier: 19.2.4
         version: 19.2.4
@@ -39,6 +36,9 @@ importers:
       '@types/node':
         specifier: ^20.19.39
         version: 20.19.39
+      '@types/pg':
+        specifier: ^8.15.6
+        version: 8.20.0
       '@types/react':
         specifier: ^19.2.14
         version: 19.2.14
@@ -547,9 +547,6 @@ packages:
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
-  '@types/better-sqlite3@7.6.13':
-    resolution: {integrity: sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==}
-
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
@@ -561,6 +558,9 @@ packages:
 
   '@types/node@20.19.39':
     resolution: {integrity: sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==}
+
+  '@types/pg@8.20.0':
+    resolution: {integrity: sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==}
 
   '@types/react-dom@19.2.3':
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
@@ -814,23 +814,10 @@ packages:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
-  base64-js@1.5.1:
-    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
-
   baseline-browser-mapping@2.10.18:
     resolution: {integrity: sha512-VSnGQAOLtP5mib/DPyg2/t+Tlv65NTBz83BJBJvmLVHHuKJVaDOBvJJykiT5TR++em5nfAySPccDZDa4oSrn8A==}
     engines: {node: '>=6.0.0'}
     hasBin: true
-
-  better-sqlite3@12.9.0:
-    resolution: {integrity: sha512-wqUv4Gm3toFpHDQmaKD4QhZm3g1DjUBI0yzS4UBl6lElUmXFYdTQmmEDpAFa5o8FiFiymURypEnfVHzILKaxqQ==}
-    engines: {node: 20.x || 22.x || 23.x || 24.x || 25.x}
-
-  bindings@1.5.0:
-    resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
-
-  bl@4.1.0:
-    resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
   brace-expansion@1.1.14:
     resolution: {integrity: sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==}
@@ -847,9 +834,6 @@ packages:
     resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
-
-  buffer@5.7.1:
-    resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
 
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
@@ -873,9 +857,6 @@ packages:
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
-
-  chownr@1.1.4:
-    resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
 
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
@@ -932,14 +913,6 @@ packages:
       supports-color:
         optional: true
 
-  decompress-response@6.0.0:
-    resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
-    engines: {node: '>=10'}
-
-  deep-extend@0.6.0:
-    resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
-    engines: {node: '>=4.0.0'}
-
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
@@ -968,9 +941,6 @@ packages:
 
   emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
-
-  end-of-stream@1.4.5:
-    resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
   enhanced-resolve@5.20.1:
     resolution: {integrity: sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==}
@@ -1136,10 +1106,6 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
-  expand-template@2.0.3:
-    resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
-    engines: {node: '>=6'}
-
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -1169,9 +1135,6 @@ packages:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
 
-  file-uri-to-path@1.0.0:
-    resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
-
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
@@ -1190,9 +1153,6 @@ packages:
   for-each@0.3.5:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
-
-  fs-constants@1.0.0:
-    resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
@@ -1226,9 +1186,6 @@ packages:
 
   get-tsconfig@4.13.7:
     resolution: {integrity: sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==}
-
-  github-from-package@0.0.0:
-    resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
 
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
@@ -1290,9 +1247,6 @@ packages:
   hermes-parser@0.25.1:
     resolution: {integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==}
 
-  ieee754@1.2.1:
-    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
-
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
@@ -1308,12 +1262,6 @@ packages:
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
-
-  inherits@2.0.4:
-    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
-
-  ini@1.3.8:
-    resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
 
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
@@ -1587,10 +1535,6 @@ packages:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
 
-  mimic-response@3.1.0:
-    resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
-    engines: {node: '>=10'}
-
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
@@ -1601,9 +1545,6 @@ packages:
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
-  mkdirp-classic@0.5.3:
-    resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
-
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
@@ -1611,9 +1552,6 @@ packages:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
-
-  napi-build-utils@2.0.0:
-    resolution: {integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==}
 
   napi-postinstall@0.3.4:
     resolution: {integrity: sha512-PHI5f1O0EP5xJ9gQmFGMS6IZcrVvTjpXjz7Na41gTE7eE2hK11lg04CECCYEEjdc17EV4DO+fkGEtt7TpTaTiQ==}
@@ -1643,10 +1581,6 @@ packages:
         optional: true
       sass:
         optional: true
-
-  node-abi@3.89.0:
-    resolution: {integrity: sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==}
-    engines: {node: '>=10'}
 
   node-exports-info@1.6.0:
     resolution: {integrity: sha512-pyFS63ptit/P5WqUkt+UUfe+4oevH+bFeIiPPdfb0pFeYEu/1ELnJu5l+5EcTKYL5M7zaAa7S8ddywgXypqKCw==}
@@ -1687,9 +1621,6 @@ packages:
     resolution: {integrity: sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==}
     engines: {node: '>= 0.4'}
 
-  once@1.4.0:
-    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
-
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
@@ -1721,6 +1652,40 @@ packages:
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
 
+  pg-cloudflare@1.3.0:
+    resolution: {integrity: sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==}
+
+  pg-connection-string@2.12.0:
+    resolution: {integrity: sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ==}
+
+  pg-int8@1.0.1:
+    resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
+    engines: {node: '>=4.0.0'}
+
+  pg-pool@3.13.0:
+    resolution: {integrity: sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA==}
+    peerDependencies:
+      pg: '>=8.0'
+
+  pg-protocol@1.13.0:
+    resolution: {integrity: sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==}
+
+  pg-types@2.2.0:
+    resolution: {integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==}
+    engines: {node: '>=4'}
+
+  pg@8.20.0:
+    resolution: {integrity: sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==}
+    engines: {node: '>= 16.0.0'}
+    peerDependencies:
+      pg-native: '>=3.0.1'
+    peerDependenciesMeta:
+      pg-native:
+        optional: true
+
+  pgpass@1.0.5:
+    resolution: {integrity: sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -1744,11 +1709,21 @@ packages:
     resolution: {integrity: sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==}
     engines: {node: ^10 || ^12 || >=14}
 
-  prebuild-install@7.1.3:
-    resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
-    engines: {node: '>=10'}
-    deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
-    hasBin: true
+  postgres-array@2.0.0:
+    resolution: {integrity: sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==}
+    engines: {node: '>=4'}
+
+  postgres-bytea@1.0.1:
+    resolution: {integrity: sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-date@1.0.7:
+    resolution: {integrity: sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-interval@1.2.0:
+    resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
+    engines: {node: '>=0.10.0'}
 
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
@@ -1757,19 +1732,12 @@ packages:
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
-  pump@3.0.4:
-    resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
-
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
-
-  rc@1.2.8:
-    resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
-    hasBin: true
 
   react-dom@19.2.4:
     resolution: {integrity: sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==}
@@ -1782,10 +1750,6 @@ packages:
   react@19.2.4:
     resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
     engines: {node: '>=0.10.0'}
-
-  readable-stream@3.6.2:
-    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
-    engines: {node: '>= 6'}
 
   reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
@@ -1817,9 +1781,6 @@ packages:
   safe-array-concat@1.1.3:
     resolution: {integrity: sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==}
     engines: {node: '>=0.4'}
-
-  safe-buffer@5.2.1:
-    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
   safe-push-apply@1.0.0:
     resolution: {integrity: sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==}
@@ -1881,15 +1842,13 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
-  simple-concat@1.0.1:
-    resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
-
-  simple-get@4.0.1:
-    resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
-
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
+
+  split2@4.2.0:
+    resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
+    engines: {node: '>= 10.x'}
 
   stable-hash@0.0.5:
     resolution: {integrity: sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==}
@@ -1921,16 +1880,9 @@ packages:
     resolution: {integrity: sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==}
     engines: {node: '>= 0.4'}
 
-  string_decoder@1.3.0:
-    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
-
   strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
     engines: {node: '>=4'}
-
-  strip-json-comments@2.0.1:
-    resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
-    engines: {node: '>=0.10.0'}
 
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
@@ -1964,13 +1916,6 @@ packages:
     resolution: {integrity: sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA==}
     engines: {node: '>=6'}
 
-  tar-fs@2.1.4:
-    resolution: {integrity: sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==}
-
-  tar-stream@2.2.0:
-    resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
-    engines: {node: '>=6'}
-
   tinyglobby@0.2.16:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
@@ -1990,9 +1935,6 @@ packages:
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
-
-  tunnel-agent@0.6.0:
-    resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
 
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
@@ -2045,9 +1987,6 @@ packages:
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
-  util-deprecate@1.0.2:
-    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
-
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
     engines: {node: '>= 0.4'}
@@ -2073,8 +2012,9 @@ packages:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
 
-  wrappy@1.0.2:
-    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+  xtend@4.0.2:
+    resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
+    engines: {node: '>=0.4'}
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
@@ -2526,10 +2466,6 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@types/better-sqlite3@7.6.13':
-    dependencies:
-      '@types/node': 20.19.39
-
   '@types/estree@1.0.8': {}
 
   '@types/json-schema@7.0.15': {}
@@ -2539,6 +2475,12 @@ snapshots:
   '@types/node@20.19.39':
     dependencies:
       undici-types: 6.21.0
+
+  '@types/pg@8.20.0':
+    dependencies:
+      '@types/node': 20.19.39
+      pg-protocol: 1.13.0
+      pg-types: 2.2.0
 
   '@types/react-dom@19.2.3(@types/react@19.2.14)':
     dependencies:
@@ -2802,24 +2744,7 @@ snapshots:
 
   balanced-match@4.0.4: {}
 
-  base64-js@1.5.1: {}
-
   baseline-browser-mapping@2.10.18: {}
-
-  better-sqlite3@12.9.0:
-    dependencies:
-      bindings: 1.5.0
-      prebuild-install: 7.1.3
-
-  bindings@1.5.0:
-    dependencies:
-      file-uri-to-path: 1.0.0
-
-  bl@4.1.0:
-    dependencies:
-      buffer: 5.7.1
-      inherits: 2.0.4
-      readable-stream: 3.6.2
 
   brace-expansion@1.1.14:
     dependencies:
@@ -2841,11 +2766,6 @@ snapshots:
       electron-to-chromium: 1.5.335
       node-releases: 2.0.37
       update-browserslist-db: 1.2.3(browserslist@4.28.2)
-
-  buffer@5.7.1:
-    dependencies:
-      base64-js: 1.5.1
-      ieee754: 1.2.1
 
   call-bind-apply-helpers@1.0.2:
     dependencies:
@@ -2872,8 +2792,6 @@ snapshots:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
-
-  chownr@1.1.4: {}
 
   client-only@0.0.1: {}
 
@@ -2923,12 +2841,6 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
-  decompress-response@6.0.0:
-    dependencies:
-      mimic-response: 3.1.0
-
-  deep-extend@0.6.0: {}
-
   deep-is@0.1.4: {}
 
   define-data-property@1.1.4:
@@ -2958,10 +2870,6 @@ snapshots:
   electron-to-chromium@1.5.335: {}
 
   emoji-regex@9.2.2: {}
-
-  end-of-stream@1.4.5:
-    dependencies:
-      once: 1.4.0
 
   enhanced-resolve@5.20.1:
     dependencies:
@@ -3278,8 +3186,6 @@ snapshots:
 
   esutils@2.0.3: {}
 
-  expand-template@2.0.3: {}
-
   fast-deep-equal@3.1.3: {}
 
   fast-glob@3.3.1:
@@ -3306,8 +3212,6 @@ snapshots:
     dependencies:
       flat-cache: 4.0.1
 
-  file-uri-to-path@1.0.0: {}
-
   fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
@@ -3327,8 +3231,6 @@ snapshots:
   for-each@0.3.5:
     dependencies:
       is-callable: 1.2.7
-
-  fs-constants@1.0.0: {}
 
   function-bind@1.1.2: {}
 
@@ -3374,8 +3276,6 @@ snapshots:
   get-tsconfig@4.13.7:
     dependencies:
       resolve-pkg-maps: 1.0.0
-
-  github-from-package@0.0.0: {}
 
   glob-parent@5.1.2:
     dependencies:
@@ -3426,8 +3326,6 @@ snapshots:
     dependencies:
       hermes-estree: 0.25.1
 
-  ieee754@1.2.1: {}
-
   ignore@5.3.2: {}
 
   ignore@7.0.5: {}
@@ -3438,10 +3336,6 @@ snapshots:
       resolve-from: 4.0.0
 
   imurmurhash@0.1.4: {}
-
-  inherits@2.0.4: {}
-
-  ini@1.3.8: {}
 
   internal-slot@1.1.0:
     dependencies:
@@ -3694,8 +3588,6 @@ snapshots:
       braces: 3.0.3
       picomatch: 2.3.2
 
-  mimic-response@3.1.0: {}
-
   minimatch@10.2.5:
     dependencies:
       brace-expansion: 5.0.5
@@ -3706,13 +3598,9 @@ snapshots:
 
   minimist@1.2.8: {}
 
-  mkdirp-classic@0.5.3: {}
-
   ms@2.1.3: {}
 
   nanoid@3.3.11: {}
-
-  napi-build-utils@2.0.0: {}
 
   napi-postinstall@0.3.4: {}
 
@@ -3741,10 +3629,6 @@ snapshots:
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
-
-  node-abi@3.89.0:
-    dependencies:
-      semver: 7.7.4
 
   node-exports-info@1.6.0:
     dependencies:
@@ -3797,10 +3681,6 @@ snapshots:
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
 
-  once@1.4.0:
-    dependencies:
-      wrappy: 1.0.2
-
   optionator@0.9.4:
     dependencies:
       deep-is: 0.1.4
@@ -3834,6 +3714,41 @@ snapshots:
 
   path-parse@1.0.7: {}
 
+  pg-cloudflare@1.3.0:
+    optional: true
+
+  pg-connection-string@2.12.0: {}
+
+  pg-int8@1.0.1: {}
+
+  pg-pool@3.13.0(pg@8.20.0):
+    dependencies:
+      pg: 8.20.0
+
+  pg-protocol@1.13.0: {}
+
+  pg-types@2.2.0:
+    dependencies:
+      pg-int8: 1.0.1
+      postgres-array: 2.0.0
+      postgres-bytea: 1.0.1
+      postgres-date: 1.0.7
+      postgres-interval: 1.2.0
+
+  pg@8.20.0:
+    dependencies:
+      pg-connection-string: 2.12.0
+      pg-pool: 3.13.0(pg@8.20.0)
+      pg-protocol: 1.13.0
+      pg-types: 2.2.0
+      pgpass: 1.0.5
+    optionalDependencies:
+      pg-cloudflare: 1.3.0
+
+  pgpass@1.0.5:
+    dependencies:
+      split2: 4.2.0
+
   picocolors@1.1.1: {}
 
   picomatch@2.3.2: {}
@@ -3854,20 +3769,15 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
-  prebuild-install@7.1.3:
+  postgres-array@2.0.0: {}
+
+  postgres-bytea@1.0.1: {}
+
+  postgres-date@1.0.7: {}
+
+  postgres-interval@1.2.0:
     dependencies:
-      detect-libc: 2.1.2
-      expand-template: 2.0.3
-      github-from-package: 0.0.0
-      minimist: 1.2.8
-      mkdirp-classic: 0.5.3
-      napi-build-utils: 2.0.0
-      node-abi: 3.89.0
-      pump: 3.0.4
-      rc: 1.2.8
-      simple-get: 4.0.1
-      tar-fs: 2.1.4
-      tunnel-agent: 0.6.0
+      xtend: 4.0.2
 
   prelude-ls@1.2.1: {}
 
@@ -3877,21 +3787,9 @@ snapshots:
       object-assign: 4.1.1
       react-is: 16.13.1
 
-  pump@3.0.4:
-    dependencies:
-      end-of-stream: 1.4.5
-      once: 1.4.0
-
   punycode@2.3.1: {}
 
   queue-microtask@1.2.3: {}
-
-  rc@1.2.8:
-    dependencies:
-      deep-extend: 0.6.0
-      ini: 1.3.8
-      minimist: 1.2.8
-      strip-json-comments: 2.0.1
 
   react-dom@19.2.4(react@19.2.4):
     dependencies:
@@ -3901,12 +3799,6 @@ snapshots:
   react-is@16.13.1: {}
 
   react@19.2.4: {}
-
-  readable-stream@3.6.2:
-    dependencies:
-      inherits: 2.0.4
-      string_decoder: 1.3.0
-      util-deprecate: 1.0.2
 
   reflect.getprototypeof@1.0.10:
     dependencies:
@@ -3954,8 +3846,6 @@ snapshots:
       get-intrinsic: 1.3.0
       has-symbols: 1.1.0
       isarray: 2.0.5
-
-  safe-buffer@5.2.1: {}
 
   safe-push-apply@1.0.0:
     dependencies:
@@ -4062,15 +3952,9 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
-  simple-concat@1.0.1: {}
-
-  simple-get@4.0.1:
-    dependencies:
-      decompress-response: 6.0.0
-      once: 1.4.0
-      simple-concat: 1.0.1
-
   source-map-js@1.2.1: {}
+
+  split2@4.2.0: {}
 
   stable-hash@0.0.5: {}
 
@@ -4129,13 +4013,7 @@ snapshots:
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
 
-  string_decoder@1.3.0:
-    dependencies:
-      safe-buffer: 5.2.1
-
   strip-bom@3.0.0: {}
-
-  strip-json-comments@2.0.1: {}
 
   strip-json-comments@3.1.1: {}
 
@@ -4155,21 +4033,6 @@ snapshots:
   tailwindcss@4.2.2: {}
 
   tapable@2.3.2: {}
-
-  tar-fs@2.1.4:
-    dependencies:
-      chownr: 1.1.4
-      mkdirp-classic: 0.5.3
-      pump: 3.0.4
-      tar-stream: 2.2.0
-
-  tar-stream@2.2.0:
-    dependencies:
-      bl: 4.1.0
-      end-of-stream: 1.4.5
-      fs-constants: 1.0.0
-      inherits: 2.0.4
-      readable-stream: 3.6.2
 
   tinyglobby@0.2.16:
     dependencies:
@@ -4192,10 +4055,6 @@ snapshots:
       strip-bom: 3.0.0
 
   tslib@2.8.1: {}
-
-  tunnel-agent@0.6.0:
-    dependencies:
-      safe-buffer: 5.2.1
 
   type-check@0.4.0:
     dependencies:
@@ -4290,8 +4149,6 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  util-deprecate@1.0.2: {}
-
   which-boxed-primitive@1.1.1:
     dependencies:
       is-bigint: 1.1.0
@@ -4339,7 +4196,7 @@ snapshots:
 
   word-wrap@1.2.5: {}
 
-  wrappy@1.0.2: {}
+  xtend@4.0.2: {}
 
   yallist@3.1.1: {}
 

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -8,8 +8,11 @@ readonly ENV_FILE="$REPO_ROOT/.env"
 
 PURGE_RUNTIME_STATE=false
 PURGE_IMAGES=false
+PURGE_ALL=false
 ASSUME_YES=false
 DOCKER_CLEANUP_SKIPPED=false
+HOST_TOOLING_CLEANUP_SKIPPED=false
+HOST_TOOLING_CLEANUP_DONE=false
 
 VERCELAB_HOST_ROOT="/opt/vercelab"
 VERCELAB_PROXY_NETWORK="vercelab_proxy"
@@ -116,18 +119,19 @@ resolve_docker_command() {
 
 print_usage() {
   cat <<'EOF'
-Usage: ./uninstall.sh [--purge] [--purge-images] [--yes]
+Usage: ./uninstall.sh [--purge] [--purge-images] [--all] [--yes]
 
 Stops and removes the Vercelab control plane plus managed deployment containers.
 
 Options:
   --purge         Remove the generated .env file, Vercelab host data, and Vercelab Docker volumes.
   --purge-images  Remove Docker images labeled for Vercelab compose projects.
+  --all           Do everything from --purge --purge-images and also remove host tooling installed by install.sh (Docker Engine/Compose plugins, Node.js, pnpm) plus local node_modules/.next.
   --yes           Skip the interactive confirmation prompt.
   --help          Show this help text.
 
 Notes:
-  - Docker Engine, the Docker Compose plugin, Node.js, and pnpm are left installed on the host.
+  - --all is destructive and removes host tooling used outside this project.
   - Without --purge, the generated .env file, database, certificates, cloned apps, and Docker volumes are preserved.
 EOF
 }
@@ -139,6 +143,11 @@ parse_args() {
         PURGE_RUNTIME_STATE=true
         ;;
       --purge-images)
+        PURGE_IMAGES=true
+        ;;
+      --all)
+        PURGE_ALL=true
+        PURGE_RUNTIME_STATE=true
         PURGE_IMAGES=true
         ;;
       --yes)
@@ -178,6 +187,7 @@ print_uninstall_review() {
   printf '%b============================================================%b\n' "$C_CYAN" "$C_RESET"
   printf ' %bPurge runtime state%b : %s\n' "$C_YELLOW" "$C_RESET" "$PURGE_RUNTIME_STATE"
   printf ' %bPurge images%b        : %s\n' "$C_YELLOW" "$C_RESET" "$PURGE_IMAGES"
+  printf ' %bPurge all tooling%b   : %s\n' "$C_YELLOW" "$C_RESET" "$PURGE_ALL"
   printf ' %bEnv file%b            : %s\n' "$C_YELLOW" "$C_RESET" "$ENV_FILE"
   printf ' %bHost root%b           : %s\n' "$C_YELLOW" "$C_RESET" "$VERCELAB_HOST_ROOT"
   printf ' %bProxy network%b       : %s\n' "$C_YELLOW" "$C_RESET" "$VERCELAB_PROXY_NETWORK"
@@ -204,6 +214,10 @@ confirm_uninstall() {
 
   if [[ "$PURGE_IMAGES" == true ]]; then
     log "It will also remove Docker images labeled for Vercelab compose projects."
+  fi
+
+  if [[ "$PURGE_ALL" == true ]]; then
+    log "It will also remove host tooling installed by install.sh (Docker Engine/Compose, Node.js, pnpm) and local build artifacts (node_modules/.next)."
   fi
 
   printf 'Continue? [y/N]: '
@@ -361,6 +375,62 @@ remove_runtime_state() {
   fi
 }
 
+remove_repo_tooling_artifacts() {
+  local target=""
+
+  for target in "$REPO_ROOT/node_modules" "$REPO_ROOT/.next"; do
+    if [[ -e "$target" ]]; then
+      log "Removing local tooling artifact $target"
+      run_privileged rm -rf -- "$target"
+    fi
+  done
+}
+
+remove_host_tooling() {
+  if [[ "$PURGE_ALL" != true ]]; then
+    return
+  fi
+
+  if (( ${#SUDO[@]} == 0 )) && [[ ${EUID} -ne 0 ]]; then
+    warn "--all requested but sudo is unavailable. Host package cleanup skipped."
+    HOST_TOOLING_CLEANUP_SKIPPED=true
+    remove_repo_tooling_artifacts
+    return
+  fi
+
+  log "Removing host tooling installed by install.sh"
+
+  remove_repo_tooling_artifacts
+
+  if command_exists npm; then
+    run_privileged npm uninstall -g pnpm >/dev/null 2>&1 || true
+  fi
+
+  if command_exists corepack; then
+    run_privileged corepack disable >/dev/null 2>&1 || true
+  fi
+
+  run_privileged apt-mark unhold docker-ce docker-ce-cli >/dev/null 2>&1 || true
+
+  run_privileged apt-get remove -y --purge \
+    docker-ce \
+    docker-ce-cli \
+    containerd.io \
+    docker-buildx-plugin \
+    docker-compose-plugin \
+    nodejs >/dev/null 2>&1 || true
+
+  run_privileged apt-get autoremove -y >/dev/null 2>&1 || true
+
+  run_privileged rm -f /etc/apt/sources.list.d/docker.list >/dev/null 2>&1 || true
+  run_privileged rm -f /etc/apt/sources.list.d/nodesource.list >/dev/null 2>&1 || true
+  run_privileged rm -f /etc/apt/keyrings/docker.asc >/dev/null 2>&1 || true
+  run_privileged rm -f /etc/apt/keyrings/nodesource.gpg >/dev/null 2>&1 || true
+  run_privileged apt-get update >/dev/null 2>&1 || true
+
+  HOST_TOOLING_CLEANUP_DONE=true
+}
+
 remove_docker_resources() {
   local projects=()
   local project=""
@@ -419,7 +489,15 @@ print_summary() {
   fi
 
   printf '\n'
-  printf ' %bHost tooling kept%b   : Docker Engine, Compose plugin, Node.js, pnpm\n' "$C_YELLOW" "$C_RESET"
+
+  if [[ "$PURGE_ALL" != true ]]; then
+    printf ' %bHost tooling kept%b   : Docker Engine, Compose plugin, Node.js, pnpm\n' "$C_YELLOW" "$C_RESET"
+  elif [[ "$HOST_TOOLING_CLEANUP_DONE" == true ]]; then
+    printf ' %bHost tooling%b        : removed (Docker Engine/Compose, Node.js, pnpm, local node_modules/.next)\n' "$C_YELLOW" "$C_RESET"
+  else
+    printf ' %bHost tooling%b        : cleanup skipped or partial (check warnings above)\n' "$C_YELLOW" "$C_RESET"
+  fi
+
   printf '%b============================================================%b\n' "$C_GREEN" "$C_RESET"
 }
 
@@ -432,6 +510,7 @@ main() {
   confirm_uninstall
   remove_docker_resources
   remove_runtime_state
+  remove_host_tooling
   print_summary
 }
 


### PR DESCRIPTION
- Added --all flag to uninstall.sh to remove host tooling and local build artifacts.
- Updated usage instructions and help text to reflect new option.
- Implemented functions to remove host tooling (Docker, Node.js, pnpm) and local node_modules/.next.
- Enhanced confirmation and summary outputs to indicate host tooling cleanup status.