### PR TITLE
Optimize dashboard loading and metrics polling

### DIFF
--- a/app/api/metrics/route.test.ts
+++ b/app/api/metrics/route.test.ts
@@ -1,0 +1,221 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  getMetricsSnapshotMock,
+  getMetricsHistoryFromInfluxMock,
+  getContainerMetricsHistoryFromInfluxMock,
+  getAllContainersMetricsHistoryFromInfluxMock,
+} = vi.hoisted(() => ({
+  getMetricsSnapshotMock: vi.fn(),
+  getMetricsHistoryFromInfluxMock: vi.fn(),
+  getContainerMetricsHistoryFromInfluxMock: vi.fn(),
+  getAllContainersMetricsHistoryFromInfluxMock: vi.fn(),
+}));
+
+vi.mock("@/lib/system-metrics", () => ({
+  getMetricsSnapshot: getMetricsSnapshotMock,
+}));
+
+vi.mock("@/lib/influx-metrics", () => ({
+  getAllContainersMetricsHistoryFromInflux:
+    getAllContainersMetricsHistoryFromInfluxMock,
+  getContainerMetricsHistoryFromInflux: getContainerMetricsHistoryFromInfluxMock,
+  getMetricsHistoryFromInflux: getMetricsHistoryFromInfluxMock,
+}));
+
+import { GET } from "@/app/api/metrics/route";
+
+describe("GET /api/metrics", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getMetricsSnapshotMock.mockResolvedValue({
+      hostIp: "10.0.0.7",
+      timestamp: "2026-04-17T08:00:00.000Z",
+      warnings: [],
+      system: {
+        cpuPercent: 12,
+        loadAverage: [0.4, 0.5, 0.6],
+        memoryPercent: 31,
+        memoryUsedBytes: 4_000,
+        memoryTotalBytes: 8_000,
+        diskReadBytesPerSecond: 120,
+        diskWriteBytesPerSecond: 88,
+      },
+      network: {
+        rxBytesPerSecond: 240,
+        txBytesPerSecond: 120,
+        interfaces: [],
+      },
+      containers: {
+        running: 1,
+        total: 1,
+        cpuPercent: 8,
+        memoryPercent: 16,
+        memoryUsedBytes: 512,
+        statusBreakdown: {
+          healthy: 1,
+          unhealthy: 0,
+          stopped: 0,
+        },
+        top: [],
+        all: [],
+      },
+    });
+  });
+
+  it("uses the lightweight current window for live polling history", async () => {
+    getMetricsHistoryFromInfluxMock.mockResolvedValue([
+      { timestamp: "2026-04-17T08:00:00.000Z", cpu: 12 },
+    ]);
+
+    const response = await GET(
+      new Request(
+        "http://localhost/api/metrics?mode=current&range=24h&includeHistory=true",
+      ),
+    );
+    const payload = await response.json();
+
+    expect(getMetricsHistoryFromInfluxMock).toHaveBeenCalledWith({
+      hostIp: "10.0.0.7",
+      limit: 48,
+      bucketSeconds: 5,
+    });
+    expect(getContainerMetricsHistoryFromInfluxMock).not.toHaveBeenCalled();
+    expect(getAllContainersMetricsHistoryFromInfluxMock).not.toHaveBeenCalled();
+    expect(payload).toMatchObject({
+      snapshot: expect.any(Object),
+      history: [{ timestamp: "2026-04-17T08:00:00.000Z", cpu: 12 }],
+    });
+    expect("containerHistory" in payload).toBe(false);
+    expect("allContainerHistory" in payload).toBe(false);
+  });
+
+  it("supports snapshot-only live polling when host history is disabled", async () => {
+    const response = await GET(
+      new Request(
+        "http://localhost/api/metrics?mode=current&includeHistory=false",
+      ),
+    );
+    const payload = await response.json();
+
+    expect(getMetricsHistoryFromInfluxMock).not.toHaveBeenCalled();
+    expect(getContainerMetricsHistoryFromInfluxMock).not.toHaveBeenCalled();
+    expect(getAllContainersMetricsHistoryFromInfluxMock).not.toHaveBeenCalled();
+    expect(payload).toEqual({
+      snapshot: expect.objectContaining({
+        hostIp: "10.0.0.7",
+      }),
+    });
+    expect("history" in payload).toBe(false);
+    expect("containerHistory" in payload).toBe(false);
+    expect("allContainerHistory" in payload).toBe(false);
+  });
+
+  it("keeps detailed live container polling on the lightweight current window", async () => {
+    getMetricsHistoryFromInfluxMock.mockResolvedValue([
+      { timestamp: "2026-04-17T08:00:00.000Z", cpu: 12 },
+    ]);
+    getContainerMetricsHistoryFromInfluxMock.mockResolvedValue([
+      { timestamp: "2026-04-17T08:00:00.000Z", cpuPercent: 8 },
+    ]);
+    getAllContainersMetricsHistoryFromInfluxMock.mockResolvedValue([
+      {
+        containerId: "runtime-control-plane",
+        containerName: "control-plane",
+        points: [{ timestamp: "2026-04-17T08:00:00.000Z", cpuPercent: 8 }],
+      },
+    ]);
+
+    const response = await GET(
+      new Request(
+        "http://localhost/api/metrics?mode=current&range=24h&containerId=runtime-control-plane&containerName=control-plane&allContainers=true",
+      ),
+    );
+    const payload = await response.json();
+
+    expect(getMetricsHistoryFromInfluxMock).toHaveBeenCalledWith({
+      hostIp: "10.0.0.7",
+      limit: 48,
+      bucketSeconds: 5,
+    });
+    expect(getContainerMetricsHistoryFromInfluxMock).toHaveBeenCalledWith({
+      hostIp: "10.0.0.7",
+      containerId: "runtime-control-plane",
+      containerName: "control-plane",
+      limit: 48,
+      bucketSeconds: 5,
+    });
+    expect(getAllContainersMetricsHistoryFromInfluxMock).toHaveBeenCalledWith({
+      hostIp: "10.0.0.7",
+      limit: 48,
+      bucketSeconds: 5,
+    });
+    expect(payload).toMatchObject({
+      snapshot: expect.any(Object),
+      history: [{ timestamp: "2026-04-17T08:00:00.000Z", cpu: 12 }],
+      containerHistory: [
+        { timestamp: "2026-04-17T08:00:00.000Z", cpuPercent: 8 },
+      ],
+      allContainerHistory: [
+        {
+          containerId: "runtime-control-plane",
+          containerName: "control-plane",
+        },
+      ],
+    });
+  });
+
+  it("loads range history only when detailed history is explicitly requested", async () => {
+    getMetricsHistoryFromInfluxMock.mockResolvedValue([
+      { timestamp: "2026-04-17T08:00:00.000Z", cpu: 12 },
+    ]);
+    getContainerMetricsHistoryFromInfluxMock.mockResolvedValue([
+      { timestamp: "2026-04-17T08:00:00.000Z", cpuPercent: 8 },
+    ]);
+    getAllContainersMetricsHistoryFromInfluxMock.mockResolvedValue([
+      {
+        containerId: "runtime-control-plane",
+        containerName: "control-plane",
+        points: [{ timestamp: "2026-04-17T08:00:00.000Z", cpuPercent: 8 }],
+      },
+    ]);
+
+    const response = await GET(
+      new Request(
+        "http://localhost/api/metrics?range=24h&containerId=runtime-control-plane&containerName=control-plane&allContainers=true",
+      ),
+    );
+    const payload = await response.json();
+
+    expect(getMetricsHistoryFromInfluxMock).toHaveBeenCalledWith({
+      hostIp: "10.0.0.7",
+      limit: 240,
+      bucketSeconds: 360,
+    });
+    expect(getContainerMetricsHistoryFromInfluxMock).toHaveBeenCalledWith({
+      hostIp: "10.0.0.7",
+      containerId: "runtime-control-plane",
+      containerName: "control-plane",
+      limit: 240,
+      bucketSeconds: 360,
+    });
+    expect(getAllContainersMetricsHistoryFromInfluxMock).toHaveBeenCalledWith({
+      hostIp: "10.0.0.7",
+      limit: 240,
+      bucketSeconds: 360,
+    });
+    expect(payload).toMatchObject({
+      snapshot: expect.any(Object),
+      history: [{ timestamp: "2026-04-17T08:00:00.000Z", cpu: 12 }],
+      containerHistory: [
+        { timestamp: "2026-04-17T08:00:00.000Z", cpuPercent: 8 },
+      ],
+      allContainerHistory: [
+        {
+          containerId: "runtime-control-plane",
+          containerName: "control-plane",
+        },
+      ],
+    });
+  });
+});

--- a/app/api/metrics/route.ts
+++ b/app/api/metrics/route.ts
@@ -2,6 +2,7 @@ import { getMetricsSnapshot } from "@/lib/system-metrics";
 import {
   type AllContainersMetricsHistorySeries,
   type ContainerMetricsHistoryPoint,
+  type MetricsHistoryPoint,
   getAllContainersMetricsHistoryFromInflux,
   getContainerMetricsHistoryFromInflux,
   getMetricsHistoryFromInflux,
@@ -13,12 +14,25 @@ import {
 
 export const dynamic = "force-dynamic";
 
+type MetricsApiResponse = {
+  snapshot: Awaited<ReturnType<typeof getMetricsSnapshot>>;
+  history?: MetricsHistoryPoint[];
+  containerHistory?: ContainerMetricsHistoryPoint[];
+  allContainerHistory?: AllContainersMetricsHistorySeries[];
+};
+
 export async function GET(request: Request) {
   const url = new URL(request.url);
   const allContainers = url.searchParams.get("allContainers") === "true";
+  const includeHistory = url.searchParams.get("includeHistory") !== "false";
+  const includeContainerHistory =
+    url.searchParams.get("includeContainerHistory") === "true";
+  const includeAllContainerHistory =
+    url.searchParams.get("includeAllContainerHistory") === "true";
   const mode = url.searchParams.get("mode");
   const containerId = url.searchParams.get("containerId")?.trim() ?? "";
   const containerName = url.searchParams.get("containerName")?.trim() ?? "";
+  const isCurrentMode = mode === "current";
 
   const maxPoints = 240;
   const currentModeLimit = 48;
@@ -28,32 +42,35 @@ export async function GET(request: Request) {
   const { bucketSeconds: rangeBucketSeconds, limit: rangeLimit } =
     getDashboardHistorySettings(range, maxPoints);
 
-  const historyLimit = mode === "current" ? currentModeLimit : rangeLimit;
-  const historyBucketSeconds =
-    mode === "current" ? currentModeBucketSeconds : rangeBucketSeconds;
+  const historyLimit = isCurrentMode ? currentModeLimit : rangeLimit;
+  const historyBucketSeconds = isCurrentMode
+    ? currentModeBucketSeconds
+    : rangeBucketSeconds;
 
   const snapshot = await getMetricsSnapshot();
   const [history, containerHistory, allContainerHistory] = await Promise.all([
-    getMetricsHistoryFromInflux({
-      hostIp: snapshot.hostIp,
-      limit: historyLimit,
-      bucketSeconds: historyBucketSeconds,
-    }).catch((error) => {
-      const message =
-        error instanceof Error
-          ? error.message
-          : "Unable to read metrics history from InfluxDB.";
+    includeHistory
+      ? getMetricsHistoryFromInflux({
+          hostIp: snapshot.hostIp,
+          limit: historyLimit,
+          bucketSeconds: historyBucketSeconds,
+        }).catch((error) => {
+          const message =
+            error instanceof Error
+              ? error.message
+              : "Unable to read metrics history from InfluxDB.";
 
-      console.error(`[metrics] ${message}`);
-      return [];
-    }),
-    containerId || containerName
+          console.error(`[metrics] ${message}`);
+          return [] as MetricsHistoryPoint[];
+        })
+      : Promise.resolve(undefined),
+    includeContainerHistory || containerId || containerName
       ? getContainerMetricsHistoryFromInflux({
           hostIp: snapshot.hostIp,
           containerId: containerId || undefined,
           containerName: containerName || undefined,
-          limit: rangeLimit,
-          bucketSeconds: rangeBucketSeconds,
+          limit: historyLimit,
+          bucketSeconds: historyBucketSeconds,
         }).catch((error) => {
           const message =
             error instanceof Error
@@ -61,14 +78,14 @@ export async function GET(request: Request) {
               : "Unable to read container history from InfluxDB.";
 
           console.error(`[metrics] ${message}`);
-          return [];
+          return [] as ContainerMetricsHistoryPoint[];
         })
-      : Promise.resolve([] as ContainerMetricsHistoryPoint[]),
-    allContainers
+      : Promise.resolve(undefined),
+    includeAllContainerHistory || allContainers
       ? getAllContainersMetricsHistoryFromInflux({
           hostIp: snapshot.hostIp,
-          limit: rangeLimit,
-          bucketSeconds: rangeBucketSeconds,
+          limit: historyLimit,
+          bucketSeconds: historyBucketSeconds,
         }).catch((error) => {
           const message =
             error instanceof Error
@@ -78,13 +95,24 @@ export async function GET(request: Request) {
           console.error(`[metrics] ${message}`);
           return [] as AllContainersMetricsHistorySeries[];
         })
-      : Promise.resolve([] as AllContainersMetricsHistorySeries[]),
+      : Promise.resolve(undefined),
   ]);
 
-  return Response.json({
+  const payload: MetricsApiResponse = {
     snapshot,
-    history,
-    containerHistory,
-    allContainerHistory,
-  });
+  };
+
+  if (history) {
+    payload.history = history;
+  }
+
+  if (containerHistory) {
+    payload.containerHistory = containerHistory;
+  }
+
+  if (allContainerHistory) {
+    payload.allContainerHistory = allContainerHistory;
+  }
+
+  return Response.json(payload);
 }

--- a/app/git-app-page/loading.tsx
+++ b/app/git-app-page/loading.tsx
@@ -1,0 +1,11 @@
+import { WorkspaceRouteLoadingShell } from "@/components/workspace/workspace-route-loading";
+
+export default function Loading() {
+  return (
+    <WorkspaceRouteLoadingShell
+      description="Loading deployment controls, repository wiring, and live app details."
+      label="Git App Page"
+      title="Opening deployment workspace"
+    />
+  );
+}

--- a/app/git-app-page/page.tsx
+++ b/app/git-app-page/page.tsx
@@ -21,7 +21,9 @@ type GitAppPageRouteProps = {
 export default async function GitAppPageRoute({
   searchParams,
 }: GitAppPageRouteProps) {
-  const pageData = await loadWorkspaceShellData(searchParams, "git-app-page");
+  const pageData = await loadWorkspaceShellData(searchParams, "git-app-page", {
+    includeMetricsHistory: false,
+  });
 
   return <WorkspaceShell {...pageData} />;
 }

--- a/app/loading.tsx
+++ b/app/loading.tsx
@@ -1,0 +1,11 @@
+import { WorkspaceRouteLoadingShell } from "@/components/workspace/workspace-route-loading";
+
+export default function Loading() {
+  return (
+    <WorkspaceRouteLoadingShell
+      description="Loading live infrastructure signals and workspace panels."
+      label="Dashboard"
+      title="Preparing workspace"
+    />
+  );
+}

--- a/components/metrics-dashboard-shell.test.tsx
+++ b/components/metrics-dashboard-shell.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import {
   afterAll,
@@ -11,8 +11,10 @@ import {
 } from "vitest";
 
 import { MetricsDashboardShell } from "@/components/metrics-dashboard-shell";
+import type { MetricsSnapshot } from "@/lib/system-metrics";
 
 const pushMock = vi.fn();
+const prefetchMock = vi.fn();
 const refreshMock = vi.fn();
 
 function jsonResponse(body: unknown, init?: ResponseInit) {
@@ -40,6 +42,7 @@ function getRequestUrl(input: Parameters<typeof fetch>[0]) {
 vi.mock("next/navigation", () => ({
   useRouter: () => ({
     push: pushMock,
+    prefetch: prefetchMock,
     refresh: refreshMock,
   }),
 }));
@@ -383,7 +386,9 @@ describe("MetricsDashboardShell", () => {
   };
 
   beforeEach(() => {
+    vi.useRealTimers();
     pushMock.mockReset();
+    prefetchMock.mockReset();
     refreshMock.mockReset();
     window.history.replaceState(null, "", "/");
 
@@ -391,6 +396,7 @@ describe("MetricsDashboardShell", () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     fetchSpy.mockReset();
   });
 
@@ -403,8 +409,9 @@ describe("MetricsDashboardShell", () => {
       <MetricsDashboardShell
         initialAllContainerHistory={payload.allContainerHistory}
         initialDashboardRange="15m"
+        initialDeployments={[]}
         initialHistory={payload.history}
-        initialSnapshot={payload.snapshot}
+        initialSnapshot={payload.snapshot as unknown as MetricsSnapshot}
       />,
     );
 
@@ -431,31 +438,53 @@ describe("MetricsDashboardShell", () => {
     expect(screen.getAllByTestId("echart-surface").length).toBe(7);
   });
 
-  it("polls range-aware metrics and stores the selected range in the URL", async () => {
+  it("avoids an immediate duplicate fetch after hydration and polls the light payload", async () => {
+    vi.useFakeTimers();
+
+    render(
+      <MetricsDashboardShell
+        initialAllContainerHistory={payload.allContainerHistory}
+        initialDashboardRange="15m"
+        initialDeployments={[]}
+        initialHistory={payload.history}
+        initialSnapshot={payload.snapshot as unknown as MetricsSnapshot}
+      />,
+    );
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(9999);
+    });
+    expect(fetchSpy).not.toHaveBeenCalled();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1);
+    });
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+    const url = getRequestUrl(fetchSpy.mock.calls[0]![0]);
+    expect(url).toContain("/api/metrics?");
+    expect(url).toContain("mode=current");
+    expect(url).toContain("range=15m");
+    expect(url).not.toContain("allContainers=true");
+  });
+
+  it("fetches live and heavy history payloads separately when the user changes range", async () => {
     const user = userEvent.setup();
 
     render(
       <MetricsDashboardShell
         initialAllContainerHistory={payload.allContainerHistory}
         initialDashboardRange="15m"
+        initialDeployments={[]}
         initialHistory={payload.history}
-        initialSnapshot={payload.snapshot}
+        initialSnapshot={payload.snapshot as unknown as MetricsSnapshot}
       />,
     );
 
-    await waitFor(() =>
-      expect(
-        fetchSpy.mock.calls.some(([input]) => {
-          const url = getRequestUrl(input);
-
-          return (
-            url.includes("/api/metrics?") &&
-            url.includes("allContainers=true") &&
-            url.includes("range=15m")
-          );
-        }),
-      ).toBe(true),
-    );
+    expect(fetchSpy).not.toHaveBeenCalled();
 
     await user.click(screen.getByRole("button", { name: /^24 h$/i }));
 
@@ -468,12 +497,61 @@ describe("MetricsDashboardShell", () => {
 
           return (
             url.includes("/api/metrics?") &&
-            url.includes("allContainers=true") &&
-            url.includes("range=24h")
+            url.includes("mode=current") &&
+            url.includes("range=24h") &&
+            !url.includes("allContainers=true")
           );
         }),
       ).toBe(true),
     );
+
+    await waitFor(() =>
+      expect(
+        fetchSpy.mock.calls.some(([input]) => {
+          const url = getRequestUrl(input);
+
+          return (
+            url.includes("/api/metrics?") &&
+            url.includes("allContainers=true") &&
+            url.includes("range=24h") &&
+            !url.includes("mode=current")
+          );
+        }),
+      ).toBe(true),
+    );
+  });
+
+  it("loads heavy container history on mount when SSR did not provide it", async () => {
+    render(
+      <MetricsDashboardShell
+        initialAllContainerHistory={[]}
+        initialDashboardRange="15m"
+        initialDeployments={[]}
+        initialHistory={payload.history}
+        initialSnapshot={payload.snapshot as unknown as MetricsSnapshot}
+      />,
+    );
+
+    await waitFor(() =>
+      expect(
+        fetchSpy.mock.calls.some(([input]) => {
+          const url = getRequestUrl(input);
+
+          return (
+            url.includes("/api/metrics?") &&
+            url.includes("allContainers=true") &&
+            url.includes("range=15m") &&
+            !url.includes("mode=current")
+          );
+        }),
+      ).toBe(true),
+    );
+
+    expect(
+      fetchSpy.mock.calls.some(([input]) =>
+        getRequestUrl(input).includes("mode=current"),
+      ),
+    ).toBe(false);
   });
 
   it("keeps fleet charts visible when focusing a container and routes rail clicks back to linked pages", async () => {
@@ -483,8 +561,9 @@ describe("MetricsDashboardShell", () => {
       <MetricsDashboardShell
         initialAllContainerHistory={payload.allContainerHistory}
         initialDashboardRange="15m"
+        initialDeployments={[]}
         initialHistory={payload.history}
-        initialSnapshot={payload.snapshot}
+        initialSnapshot={payload.snapshot as unknown as MetricsSnapshot}
       />,
     );
 
@@ -622,7 +701,7 @@ describe("MetricsDashboardShell", () => {
           cpuPercent: 24,
           diskReadBytesPerSecond: 70_000,
           diskWriteBytesPerSecond: 84_000,
-          loadAverage: [0.42, 0.46, 0.5],
+          loadAverage: [0.42, 0.46, 0.5] as [number, number, number],
           memoryPercent: 61,
           memoryTotalBytes: 64 * 1024 ** 3,
           memoryUsedBytes: Math.round(39 * 1024 ** 3),
@@ -661,7 +740,7 @@ describe("MetricsDashboardShell", () => {
           },
         ]}
         initialHistory={labelPayload.history}
-        initialSnapshot={labelPayload.snapshot}
+        initialSnapshot={labelPayload.snapshot as unknown as MetricsSnapshot}
       />,
     );
 

--- a/components/metrics-dashboard-shell.tsx
+++ b/components/metrics-dashboard-shell.tsx
@@ -58,7 +58,10 @@ const MIN_LIST_WIDTH_PX = 260;
 const MAX_LIST_WIDTH_PX = 420;
 const MIN_LOGS_WIDTH_PX = 300;
 const MAX_LOGS_WIDTH_PX = 520;
-const POLL_INTERVAL_MS = 5000;
+const LIVE_POLL_INTERVAL_MS = 10000;
+const HIDDEN_LIVE_POLL_INTERVAL_MS = 30000;
+const LIVE_POLL_ERROR_BACKOFF_MAX_MS = 60000;
+const VISIBILITY_REFRESH_DELAY_MS = 750;
 
 const WORKSPACE_RAIL_ITEMS: Array<{
   description: string;
@@ -101,6 +104,28 @@ function getStorage() {
 
 function clamp(value: number, min: number, max: number) {
   return Math.min(max, Math.max(min, value));
+}
+
+function buildMetricsRequestUrl(
+  searchParams: Record<string, string | undefined>,
+) {
+  const params = new URLSearchParams();
+
+  for (const [key, value] of Object.entries(searchParams)) {
+    if (typeof value === "string") {
+      params.set(key, value);
+    }
+  }
+
+  return "/api/metrics?" + params.toString();
+}
+
+function isDocumentHidden() {
+  if (typeof document === "undefined") {
+    return false;
+  }
+
+  return document.visibilityState === "hidden";
 }
 
 function useStoredPanelWidth(
@@ -181,6 +206,10 @@ export function MetricsDashboardShell({
     AllContainersMetricsHistorySeries[]
   >(initialAllContainerHistory);
   const [metricsError, setMetricsError] = useState<string | null>(null);
+  const [containerHistoryError, setContainerHistoryError] = useState<string | null>(null);
+  const [isContainerHistoryLoading, setIsContainerHistoryLoading] = useState(
+    initialSnapshot !== null && initialAllContainerHistory.length === 0,
+  );
   const dragStateRef = useRef<{
     kind: "metrics" | "list" | "logs" | null;
     startWidth: number;
@@ -190,6 +219,13 @@ export function MetricsDashboardShell({
     startWidth: 0,
     startX: 0,
   });
+  const hasMountedLivePollingRef = useRef(false);
+  const hasMountedContainerHistoryRef = useRef(false);
+  const livePollInFlightRef = useRef(false);
+  const containerHistoryInFlightRef = useRef(false);
+  const loadedContainerHistoryRangeRef = useRef<string | null>(
+    initialAllContainerHistory.length ? initialDashboardRange : null,
+  );
   const serverMetrics = useMemo(
     () => buildLiveServerMetrics(sidebarSnapshot, sidebarHistory),
     [sidebarHistory, sidebarSnapshot],
@@ -299,40 +335,85 @@ export function MetricsDashboardShell({
 
   useEffect(() => {
     let active = true;
+    let timeoutId: number | null = null;
+    let abortController: AbortController | null = null;
+    let errorBackoffMs = LIVE_POLL_INTERVAL_MS;
 
-    const poll = async () => {
+    const scheduleNextPoll = (delayMs: number) => {
+      if (!active) {
+        return;
+      }
+
+      if (timeoutId !== null) {
+        window.clearTimeout(timeoutId);
+      }
+
+      timeoutId = window.setTimeout(() => {
+        void pollLiveMetrics();
+      }, delayMs);
+    };
+
+    const pollLiveMetrics = async () => {
+      if (!active) {
+        return;
+      }
+
+      if (livePollInFlightRef.current) {
+        scheduleNextPoll(errorBackoffMs);
+        return;
+      }
+
+      if (isDocumentHidden()) {
+        scheduleNextPoll(HIDDEN_LIVE_POLL_INTERVAL_MS);
+        return;
+      }
+
+      livePollInFlightRef.current = true;
+      abortController = new AbortController();
+
       try {
-        const searchParams = new URLSearchParams({
-          allContainers: "true",
-          range: dashboardRange,
-        });
         const response = await fetch(
-          `/api/metrics?${searchParams.toString()}`,
+          buildMetricsRequestUrl({
+            includeHistory: "true",
+            mode: "current",
+            range: dashboardRange,
+          }),
           {
             cache: "no-store",
+            signal: abortController.signal,
           },
         );
 
         if (!response.ok) {
-          throw new Error(`Metrics request failed with ${response.status}.`);
+          throw new Error(
+            "Metrics request failed with " + response.status + ".",
+          );
         }
 
         const payload = (await response.json()) as {
-          allContainerHistory?: AllContainersMetricsHistorySeries[];
           history?: MetricsHistoryPoint[];
-          snapshot: MetricsSnapshot;
+          snapshot?: MetricsSnapshot | null;
         };
 
         if (!active) {
           return;
         }
 
-        setSidebarSnapshot(payload.snapshot);
-        setSidebarHistory(payload.history ?? []);
-        setAllContainerHistory(payload.allContainerHistory ?? []);
+        if (payload.snapshot) {
+          setSidebarSnapshot(payload.snapshot);
+        }
+
+        if (Array.isArray(payload.history)) {
+          setSidebarHistory(payload.history);
+        }
+
         setMetricsError(null);
+        errorBackoffMs = LIVE_POLL_INTERVAL_MS;
       } catch (error) {
-        if (!active) {
+        if (
+          !active ||
+          (error instanceof DOMException && error.name === "AbortError")
+        ) {
           return;
         }
 
@@ -341,20 +422,163 @@ export function MetricsDashboardShell({
             ? error.message
             : "Unable to load live metrics.",
         );
+        errorBackoffMs = Math.min(
+          errorBackoffMs * 2,
+          LIVE_POLL_ERROR_BACKOFF_MAX_MS,
+        );
+      } finally {
+        livePollInFlightRef.current = false;
+        abortController = null;
+        scheduleNextPoll(errorBackoffMs);
       }
     };
 
-    void poll();
+    const shouldPollImmediately = hasMountedLivePollingRef.current
+      ? true
+      : !(initialSnapshot && initialHistory.length > 0);
 
-    const intervalId = window.setInterval(() => {
-      void poll();
-    }, POLL_INTERVAL_MS);
+    hasMountedLivePollingRef.current = true;
+    scheduleNextPoll(shouldPollImmediately ? 0 : LIVE_POLL_INTERVAL_MS);
+
+    const handleVisibilityChange = () => {
+      if (document.visibilityState !== "visible") {
+        return;
+      }
+
+      scheduleNextPoll(VISIBILITY_REFRESH_DELAY_MS);
+    };
+
+    document.addEventListener("visibilitychange", handleVisibilityChange);
 
     return () => {
       active = false;
-      window.clearInterval(intervalId);
+      livePollInFlightRef.current = false;
+      abortController?.abort();
+
+      if (timeoutId !== null) {
+        window.clearTimeout(timeoutId);
+      }
+
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
     };
-  }, [dashboardRange]);
+  }, [dashboardRange, initialHistory.length, initialSnapshot]);
+
+  useEffect(() => {
+    const requestedRange = dashboardRange;
+    const hasHistoryForRange =
+      loadedContainerHistoryRangeRef.current === requestedRange;
+
+    if (hasHistoryForRange) {
+      setIsContainerHistoryLoading(false);
+      setContainerHistoryError(null);
+
+      if (!hasMountedContainerHistoryRef.current) {
+        hasMountedContainerHistoryRef.current = true;
+      }
+
+      return;
+    }
+
+    let active = true;
+    const abortController = new AbortController();
+    const shouldFetchImmediately = hasMountedContainerHistoryRef.current
+      ? true
+      : allContainerHistory.length === 0;
+
+    hasMountedContainerHistoryRef.current = true;
+
+    if (!shouldFetchImmediately) {
+      return;
+    }
+
+    setIsContainerHistoryLoading(true);
+
+    const loadContainerHistory = async () => {
+      if (!active || containerHistoryInFlightRef.current) {
+        return;
+      }
+
+      containerHistoryInFlightRef.current = true;
+
+      try {
+        const response = await fetch(
+          buildMetricsRequestUrl({
+            allContainers: "true",
+            includeAllContainerHistory: "true",
+            includeHistory: "false",
+            range: requestedRange,
+          }),
+          {
+            cache: "no-store",
+            signal: abortController.signal,
+          },
+        );
+
+        if (!response.ok) {
+          throw new Error(
+            "Metrics request failed with " + response.status + ".",
+          );
+        }
+
+        const payload = (await response.json()) as {
+          allContainerHistory?: AllContainersMetricsHistorySeries[];
+          history?: MetricsHistoryPoint[];
+          snapshot?: MetricsSnapshot | null;
+        };
+
+        if (!active) {
+          return;
+        }
+
+        if (payload.snapshot && !sidebarSnapshot) {
+          setSidebarSnapshot(payload.snapshot);
+        }
+
+        if (Array.isArray(payload.history) && sidebarHistory.length === 0) {
+          setSidebarHistory(payload.history);
+        }
+
+        if (Array.isArray(payload.allContainerHistory)) {
+          setAllContainerHistory(payload.allContainerHistory);
+          loadedContainerHistoryRangeRef.current = requestedRange;
+        }
+
+        setContainerHistoryError(null);
+      } catch (error) {
+        if (
+          !active ||
+          (error instanceof DOMException && error.name === "AbortError")
+        ) {
+          return;
+        }
+
+        setContainerHistoryError(
+          error instanceof Error
+            ? error.message
+            : "Unable to load container history.",
+        );
+      } finally {
+        containerHistoryInFlightRef.current = false;
+
+        if (active) {
+          setIsContainerHistoryLoading(false);
+        }
+      }
+    };
+
+    void loadContainerHistory();
+
+    return () => {
+      active = false;
+      abortController.abort();
+      containerHistoryInFlightRef.current = false;
+    };
+  }, [
+    allContainerHistory.length,
+    dashboardRange,
+    sidebarHistory.length,
+    sidebarSnapshot,
+  ]);
 
   useEffect(() => {
     function handleMouseMove(event: MouseEvent) {
@@ -559,7 +783,9 @@ export function MetricsDashboardShell({
         <main className="min-w-0 flex-1 overflow-auto bg-linear-to-b from-background/72 via-muted/14 to-background p-4 md:p-5">
           <MetricsDashboardMainContent
             allContainerHistory={allContainerHistory}
+            containerHistoryStatusText={containerHistoryError}
             deployments={initialDeployments}
+            isAllContainerHistoryLoading={isContainerHistoryLoading}
             onRangeChangeAction={setDashboardRange}
             range={dashboardRange}
             rangeOptions={METRICS_DASHBOARD_RANGE_OPTIONS}

--- a/components/ui/echart-surface.tsx
+++ b/components/ui/echart-surface.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef } from "react";
+import { memo, useEffect, useRef } from "react";
 
 import { cn } from "@/lib/utils";
 import type { EChartsCoreOption, EChartsType, SetOptionOpts } from "echarts";
@@ -12,7 +12,17 @@ type EChartSurfaceProps = {
   setOptionOptions?: SetOptionOpts;
 };
 
-export function EChartSurface({
+let echartsModulePromise: Promise<typeof import("echarts")> | null = null;
+
+function loadECharts() {
+  if (!echartsModulePromise) {
+    echartsModulePromise = import("echarts");
+  }
+
+  return echartsModulePromise;
+}
+
+export const EChartSurface = memo(function EChartSurface({
   ariaLabel,
   className,
   option,
@@ -24,6 +34,32 @@ export function EChartSurface({
   const setOptionOptionsRef = useRef(setOptionOptions);
 
   useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const warmCharts = () => {
+      void loadECharts();
+    };
+
+    if ("requestIdleCallback" in window) {
+      const handle = window.requestIdleCallback(warmCharts, {
+        timeout: 1500,
+      });
+
+      return () => {
+        window.cancelIdleCallback(handle);
+      };
+    }
+
+    const timeoutId = globalThis.setTimeout(warmCharts, 250);
+
+    return () => {
+      globalThis.clearTimeout(timeoutId);
+    };
+  }, []);
+
+  useEffect(() => {
     const element = elementRef.current;
 
     if (!element) {
@@ -32,9 +68,14 @@ export function EChartSurface({
 
     let active = true;
     let resizeObserver: ResizeObserver | null = null;
+    let intersectionObserver: IntersectionObserver | null = null;
 
-    async function mountChart() {
-      const echarts = await import("echarts");
+    const initializeChart = async () => {
+      if (!active || chartRef.current) {
+        return;
+      }
+
+      const echarts = await loadECharts();
 
       if (!active || !element) {
         return;
@@ -49,12 +90,30 @@ export function EChartSurface({
         instance.resize();
       });
       resizeObserver.observe(element);
-    }
+    };
 
-    void mountChart();
+    if (typeof IntersectionObserver !== "function") {
+      void initializeChart();
+    } else {
+      intersectionObserver = new IntersectionObserver(
+        (entries) => {
+          if (!entries.some((entry) => entry.isIntersecting)) {
+            return;
+          }
+
+          intersectionObserver?.disconnect();
+          intersectionObserver = null;
+          void initializeChart();
+        },
+        { rootMargin: "240px 0px" },
+      );
+
+      intersectionObserver.observe(element);
+    }
 
     return () => {
       active = false;
+      intersectionObserver?.disconnect();
       resizeObserver?.disconnect();
       chartRef.current?.dispose();
       chartRef.current = null;
@@ -75,4 +134,4 @@ export function EChartSurface({
       role="img"
     />
   );
-}
+});

--- a/components/workspace-shell.test.tsx
+++ b/components/workspace-shell.test.tsx
@@ -13,6 +13,7 @@ import {
 import { WorkspaceShell } from "@/components/workspace-shell";
 
 const pushMock = vi.fn();
+const prefetchMock = vi.fn();
 const refreshMock = vi.fn();
 
 function jsonResponse(body: unknown, init?: ResponseInit) {
@@ -40,6 +41,7 @@ function getRequestUrl(input: Parameters<typeof fetch>[0]) {
 vi.mock("next/navigation", () => ({
   useRouter: () => ({
     push: pushMock,
+    prefetch: prefetchMock,
     refresh: refreshMock,
   }),
 }));
@@ -49,6 +51,7 @@ describe("WorkspaceShell", () => {
 
   beforeEach(() => {
     pushMock.mockReset();
+    prefetchMock.mockReset();
     refreshMock.mockReset();
     window.history.replaceState(null, "", "/");
 
@@ -753,6 +756,32 @@ describe("WorkspaceShell", () => {
     );
 
     expect(pushMock).toHaveBeenCalledWith("/git-app-page?range=24h");
+  });
+
+  it("prefetches the inactive workspace view and keeps the selected range", async () => {
+    window.history.replaceState(null, "", "/?range=24h");
+
+    render(<WorkspaceShell initialDashboardRange="24h" />);
+
+    await waitFor(() => {
+      expect(prefetchMock).toHaveBeenCalledWith("/git-app-page?range=24h");
+    });
+  });
+
+  it("skips live metrics polling on the git app page first paint", async () => {
+    render(<WorkspaceShell initialView="git-app-page" />);
+
+    await waitFor(() => {
+      expect(
+        fetchSpy.mock.calls.some(([input]) => getRequestUrl(input) === "/api/github/repos"),
+      ).toBe(true);
+    });
+
+    expect(
+      fetchSpy.mock.calls.some(([input]) =>
+        getRequestUrl(input).includes("/api/metrics?"),
+      ),
+    ).toBe(false);
   });
 
   it("renders the git app page with editable deployment details", async () => {

--- a/components/workspace-shell.tsx
+++ b/components/workspace-shell.tsx
@@ -168,6 +168,9 @@ const DEFAULT_LIST_WIDTH_PX = 304;
 const DEFAULT_LOGS_WIDTH_PX = 340;
 const EMPTY_DEPLOYMENTS: DeploymentSummary[] = [];
 const EMPTY_CONTAINER_HISTORY: ContainerMetricsHistoryPoint[] = [];
+const EMPTY_CONTAINER_LIST: ContainerListEntry[] = [];
+const EMPTY_FOCUSED_METRIC_CHARTS: FocusedMetricChart[] = [];
+const EMPTY_ALL_CONTAINERS_METRIC_CHARTS: AllContainersMetricChart[] = [];
 
 const MIN_METRICS_WIDTH_PX = 216;
 const MAX_METRICS_WIDTH_PX = 420;
@@ -175,7 +178,10 @@ const MIN_LIST_WIDTH_PX = 260;
 const MAX_LIST_WIDTH_PX = 420;
 const MIN_LOGS_WIDTH_PX = 300;
 const MAX_LOGS_WIDTH_PX = 520;
-const POLL_INTERVAL_MS = 5000;
+const LIVE_POLL_INTERVAL_MS = 10000;
+const HIDDEN_LIVE_POLL_INTERVAL_MS = 30000;
+const LIVE_POLL_ERROR_BACKOFF_MAX_MS = 60000;
+const VISIBILITY_REFRESH_DELAY_MS = 750;
 const ALL_CONTAINERS_ID = "__all-containers__";
 const STABLE_TIME_ZONE = "UTC";
 const ALL_CONTAINERS_RANGE_OPTIONS = DASHBOARD_RANGE_OPTIONS.filter(
@@ -1693,6 +1699,28 @@ function getWorkspaceViewHref(view: WorkspaceView, range: DashboardRange) {
   return `${pathname}?${searchParams.toString()}`;
 }
 
+function buildMetricsRequestUrl(
+  searchParams: Record<string, string | undefined>,
+) {
+  const params = new URLSearchParams();
+
+  for (const [key, value] of Object.entries(searchParams)) {
+    if (typeof value === "string") {
+      params.set(key, value);
+    }
+  }
+
+  return `/api/metrics?${params.toString()}`;
+}
+
+function isDocumentHidden() {
+  if (typeof document === "undefined") {
+    return false;
+  }
+
+  return document.visibilityState === "hidden";
+}
+
 function toSlug(value: string) {
   return value
     .toLowerCase()
@@ -1954,6 +1982,11 @@ export function WorkspaceShell({
   const [metricsError, setMetricsError] = useState<string | null>(null);
   const branchCacheRef = useRef<Record<string, string[]>>({});
   const branchRequestIdRef = useRef(0);
+  const hasMountedLivePollingRef = useRef(false);
+  const hasMountedDetailedHistoryRef = useRef(false);
+  const livePollInFlightRef = useRef(false);
+  const detailedHistoryInFlightRef = useRef(false);
+  const loadedDetailedHistoryKeyRef = useRef<string | null>(null);
   const dragStateRef = useRef<{
     kind: "metrics" | "list" | "logs" | null;
     startWidth: number;
@@ -1968,8 +2001,11 @@ export function WorkspaceShell({
     [sidebarHistory, sidebarSnapshot],
   );
   const workspaceContainers = useMemo(
-    () => buildContainerListEntries(sidebarSnapshot, deployments),
-    [deployments, sidebarSnapshot],
+    () =>
+      activeView === "dashboard"
+        ? buildContainerListEntries(sidebarSnapshot, deployments)
+        : EMPTY_CONTAINER_LIST,
+    [activeView, deployments, sidebarSnapshot],
   );
   const metricsStatus = metricsError
     ? {
@@ -1984,6 +2020,14 @@ export function WorkspaceShell({
             "border-emerald-200/80 bg-emerald-50/90 text-emerald-700",
           helperText: `Updated ${formatClock(sidebarSnapshot.timestamp)} from Influx-backed history.`,
         }
+      : sidebarSnapshot && activeView !== "dashboard"
+        ? {
+            badgeLabel: "Snapshot only",
+            badgeClassName:
+              "border-amber-200/80 bg-amber-50/90 text-amber-700",
+            helperText:
+              "Git App Page keeps the sidebar light and refreshes detailed charts only on the dashboard.",
+          }
       : sidebarSnapshot
         ? {
             badgeLabel: "Snapshot only",
@@ -1998,6 +2042,10 @@ export function WorkspaceShell({
           };
 
   const filteredContainers = useMemo(() => {
+    if (activeView !== "dashboard") {
+      return EMPTY_CONTAINER_LIST;
+    }
+
     const normalizedQuery = searchQuery.trim().toLowerCase();
 
     if (!normalizedQuery) {
@@ -2007,7 +2055,7 @@ export function WorkspaceShell({
     return workspaceContainers.filter((container) =>
       container.searchText.includes(normalizedQuery),
     );
-  }, [searchQuery, workspaceContainers]);
+  }, [activeView, searchQuery, workspaceContainers]);
   const repositoryOptions = useMemo(
     () => buildRepositoryOptions(repositoryState.repositories),
     [repositoryState.repositories],
@@ -2108,28 +2156,74 @@ export function WorkspaceShell({
     selectedContainerHistoryKey === selectedRuntimeContainerKey
       ? selectedContainerHistory
       : EMPTY_CONTAINER_HISTORY;
-  const focusedMetricCharts = useMemo(
-    () =>
-      buildFocusedMetricCharts(
-        selectedRuntimeContainer,
-        activeSelectedContainerHistory,
-        selectedContainer,
-      ),
-    [
+  const focusedMetricCharts = useMemo(() => {
+    if (activeView !== "dashboard") {
+      return EMPTY_FOCUSED_METRIC_CHARTS;
+    }
+
+    return buildFocusedMetricCharts(
+      selectedRuntimeContainer,
       activeSelectedContainerHistory,
       selectedContainer,
-      selectedRuntimeContainer,
-    ],
-  );
-  const allContainersMetricCharts = useMemo(
-    () =>
-      buildAllContainersMetricCharts(
-        dashboardRange,
-        sidebarSnapshot,
-        allContainerHistory,
-      ),
-    [allContainerHistory, dashboardRange, sidebarSnapshot],
-  );
+    );
+  }, [
+    activeSelectedContainerHistory,
+    activeView,
+    selectedContainer,
+    selectedRuntimeContainer,
+  ]);
+  const allContainersMetricCharts = useMemo(() => {
+    if (activeView !== "dashboard") {
+      return EMPTY_ALL_CONTAINERS_METRIC_CHARTS;
+    }
+
+    return buildAllContainersMetricCharts(
+      dashboardRange,
+      sidebarSnapshot,
+      allContainerHistory,
+    );
+  }, [activeView, allContainerHistory, dashboardRange, sidebarSnapshot]);
+  const detailedHistoryRequest = useMemo(() => {
+    if (activeView !== "dashboard") {
+      return null;
+    }
+
+    if (isAllContainersSelected) {
+      return {
+        key: `all:${dashboardRange}`,
+        searchParams: {
+          allContainers: "true",
+          includeAllContainerHistory: "true",
+          includeHistory: "false",
+          range: dashboardRange,
+        } satisfies Record<string, string>,
+        target: "all-containers" as const,
+      };
+    }
+
+    if (!selectedRuntimeContainerId || !selectedRuntimeContainerName) {
+      return null;
+    }
+
+    return {
+      key: `${selectedRuntimeContainerKey ?? selectedRuntimeContainerId}:${dashboardRange}`,
+      searchParams: {
+        containerId: selectedRuntimeContainerId,
+        containerName: selectedRuntimeContainerName,
+        includeContainerHistory: "true",
+        includeHistory: "false",
+        range: dashboardRange,
+      } satisfies Record<string, string>,
+      target: "container" as const,
+    };
+  }, [
+    activeView,
+    dashboardRange,
+    isAllContainersSelected,
+    selectedRuntimeContainerId,
+    selectedRuntimeContainerKey,
+    selectedRuntimeContainerName,
+  ]);
 
   useEffect(() => {
     setDeployments(deploymentSeed);
@@ -2173,31 +2267,59 @@ export function WorkspaceShell({
 
   useEffect(() => {
     let active = true;
-    const activeHistoryKey =
-      !isAllContainersSelected &&
-      selectedRuntimeContainerId &&
-      selectedRuntimeContainerName
-        ? `${selectedRuntimeContainerId}:${selectedRuntimeContainerName}`
-        : null;
+    let timeoutId: number | null = null;
+    let abortController: AbortController | null = null;
+    let errorBackoffMs = LIVE_POLL_INTERVAL_MS;
 
-    const poll = async () => {
+    const scheduleNextPoll = (delayMs: number) => {
+      if (!active) {
+        return;
+      }
+
+      if (timeoutId !== null) {
+        window.clearTimeout(timeoutId);
+      }
+
+      timeoutId = window.setTimeout(() => {
+        void pollLiveMetrics();
+      }, delayMs);
+    };
+
+    const pollLiveMetrics = async () => {
+      if (!active) {
+        return;
+      }
+
+      if (livePollInFlightRef.current) {
+        scheduleNextPoll(errorBackoffMs);
+        return;
+      }
+
+      if (isDocumentHidden()) {
+        scheduleNextPoll(HIDDEN_LIVE_POLL_INTERVAL_MS);
+        return;
+      }
+
+      livePollInFlightRef.current = true;
+      abortController = new AbortController();
+
       try {
-        const searchParams = new URLSearchParams({
-          mode: "current",
-          range: dashboardRange,
-        });
-
-        if (isAllContainersSelected) {
-          searchParams.set("allContainers", "true");
-        } else if (selectedRuntimeContainerId && selectedRuntimeContainerName) {
-          searchParams.set("containerId", selectedRuntimeContainerId);
-          searchParams.set("containerName", selectedRuntimeContainerName);
-        }
-
         const response = await fetch(
-          `/api/metrics?${searchParams.toString()}`,
+          buildMetricsRequestUrl(
+            activeView === "dashboard"
+              ? {
+                  includeHistory: "true",
+                  mode: "current",
+                  range: dashboardRange,
+                }
+              : {
+                  includeHistory: "false",
+                  mode: "current",
+                },
+          ),
           {
             cache: "no-store",
+            signal: abortController.signal,
           },
         );
 
@@ -2206,31 +2328,29 @@ export function WorkspaceShell({
         }
 
         const payload = (await response.json()) as {
-          allContainerHistory?: AllContainersMetricsHistorySeries[];
-          containerHistory?: ContainerMetricsHistoryPoint[];
-          snapshot: MetricsSnapshot;
-          history: MetricsHistoryPoint[];
+          history?: MetricsHistoryPoint[];
+          snapshot?: MetricsSnapshot | null;
         };
 
         if (!active) {
           return;
         }
 
-        setSidebarSnapshot(payload.snapshot);
-        setSidebarHistory(payload.history ?? []);
+        if (payload.snapshot) {
+          setSidebarSnapshot(payload.snapshot);
+        }
 
-        if (isAllContainersSelected) {
-          setAllContainerHistory(payload.allContainerHistory ?? []);
-          setSelectedContainerHistory([]);
-          setSelectedContainerHistoryKey(null);
-        } else {
-          setSelectedContainerHistory(payload.containerHistory ?? []);
-          setSelectedContainerHistoryKey(activeHistoryKey);
+        if (Array.isArray(payload.history)) {
+          setSidebarHistory(payload.history);
         }
 
         setMetricsError(null);
+        errorBackoffMs = LIVE_POLL_INTERVAL_MS;
       } catch (error) {
-        if (!active) {
+        if (
+          !active ||
+          (error instanceof DOMException && error.name === "AbortError")
+        ) {
           return;
         }
 
@@ -2241,23 +2361,140 @@ export function WorkspaceShell({
 
         console.error(message);
         setMetricsError(message);
+        errorBackoffMs = Math.min(
+          errorBackoffMs * 2,
+          LIVE_POLL_ERROR_BACKOFF_MAX_MS,
+        );
+      } finally {
+        livePollInFlightRef.current = false;
+        abortController = null;
+        scheduleNextPoll(errorBackoffMs);
       }
     };
 
-    void poll();
-    const intervalId = window.setInterval(() => {
-      void poll();
-    }, POLL_INTERVAL_MS);
+    const shouldPollImmediately =
+      activeView === "dashboard"
+        ? hasMountedLivePollingRef.current
+          ? true
+          : !(initialSnapshot && initialHistory.length > 0)
+        : false;
+
+    hasMountedLivePollingRef.current = true;
+    scheduleNextPoll(shouldPollImmediately ? 0 : LIVE_POLL_INTERVAL_MS);
+
+    const handleVisibilityChange = () => {
+      if (document.visibilityState !== "visible") {
+        return;
+      }
+
+      scheduleNextPoll(VISIBILITY_REFRESH_DELAY_MS);
+    };
+
+    document.addEventListener("visibilitychange", handleVisibilityChange);
 
     return () => {
       active = false;
-      window.clearInterval(intervalId);
+      livePollInFlightRef.current = false;
+      abortController?.abort();
+
+      if (timeoutId !== null) {
+        window.clearTimeout(timeoutId);
+      }
+
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+    };
+  }, [activeView, dashboardRange, initialHistory.length, initialSnapshot]);
+
+  useEffect(() => {
+    if (!detailedHistoryRequest) {
+      return;
+    }
+
+    if (loadedDetailedHistoryKeyRef.current === detailedHistoryRequest.key) {
+      if (!hasMountedDetailedHistoryRef.current) {
+        hasMountedDetailedHistoryRef.current = true;
+      }
+
+      return;
+    }
+
+    let active = true;
+    const abortController = new AbortController();
+    const shouldFetchImmediately = hasMountedDetailedHistoryRef.current
+      ? true
+      : detailedHistoryRequest.target === "all-containers"
+        ? allContainerHistory.length === 0
+        : selectedContainerHistory.length === 0;
+
+    hasMountedDetailedHistoryRef.current = true;
+
+    if (!shouldFetchImmediately) {
+      return;
+    }
+
+    const loadDetailedHistory = async () => {
+      if (!active || detailedHistoryInFlightRef.current) {
+        return;
+      }
+
+      detailedHistoryInFlightRef.current = true;
+
+      try {
+        const response = await fetch(
+          buildMetricsRequestUrl(detailedHistoryRequest.searchParams),
+          {
+            cache: "no-store",
+            signal: abortController.signal,
+          },
+        );
+
+        if (!response.ok) {
+          throw new Error(`Metrics request failed with ${response.status}.`);
+        }
+
+        const payload = (await response.json()) as {
+          allContainerHistory?: AllContainersMetricsHistorySeries[];
+          containerHistory?: ContainerMetricsHistoryPoint[];
+        };
+
+        if (!active) {
+          return;
+        }
+
+        if (detailedHistoryRequest.target === "all-containers") {
+          setAllContainerHistory(payload.allContainerHistory ?? []);
+          setSelectedContainerHistory([]);
+          setSelectedContainerHistoryKey(null);
+        } else {
+          setSelectedContainerHistory(payload.containerHistory ?? []);
+          setSelectedContainerHistoryKey(selectedRuntimeContainerKey);
+        }
+
+        loadedDetailedHistoryKeyRef.current = detailedHistoryRequest.key;
+      } catch (error) {
+        if (
+          !active ||
+          (error instanceof DOMException && error.name === "AbortError")
+        ) {
+          return;
+        }
+      } finally {
+        detailedHistoryInFlightRef.current = false;
+      }
+    };
+
+    void loadDetailedHistory();
+
+    return () => {
+      active = false;
+      abortController.abort();
+      detailedHistoryInFlightRef.current = false;
     };
   }, [
-    dashboardRange,
-    isAllContainersSelected,
-    selectedRuntimeContainerId,
-    selectedRuntimeContainerName,
+    allContainerHistory.length,
+    detailedHistoryRequest,
+    selectedContainerHistory.length,
+    selectedRuntimeContainerKey,
   ]);
 
   useEffect(() => {
@@ -2769,7 +3006,8 @@ export function WorkspaceShell({
     onResizeStartAction: (event: ReactMouseEvent<HTMLDivElement>) =>
       handleResizeStart("metrics", event),
     showStateWarning: Boolean(
-      (sidebarSnapshot && !sidebarHistory.length) || metricsError,
+      (activeView === "dashboard" && sidebarSnapshot && !sidebarHistory.length) ||
+        metricsError,
     ),
     summaryLabel: sidebarSnapshot
       ? `${sidebarSnapshot.containers.running} running containers on ${sidebarSnapshot.hostIp}.`

--- a/components/workspace/metrics-dashboard-main-content.tsx
+++ b/components/workspace/metrics-dashboard-main-content.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo } from "react";
+import { memo, useMemo } from "react";
 
 import { EChartSurface } from "@/components/ui/echart-surface";
 import { Badge } from "@/components/ui/badge";
@@ -31,7 +31,9 @@ import type { EChartsCoreOption } from "echarts";
 
 type MetricsDashboardMainContentProps = {
   allContainerHistory: AllContainersMetricsHistorySeries[];
+  containerHistoryStatusText?: string | null;
   deployments: DeploymentSummary[];
+  isAllContainerHistoryLoading?: boolean;
   onRangeChangeAction: (range: DashboardRange) => void;
   range: DashboardRange;
   rangeOptions: ReadonlyArray<{
@@ -102,6 +104,8 @@ function createTooltipShell(title: string, rows: string) {
 function createTooltipRow(label: string, value: string, color?: string) {
   return `<div style="display:flex; align-items:center; justify-content:space-between; gap:16px; font-size:12px; line-height:1.5;"><span style="display:flex; align-items:center; gap:8px; color:#cbd5e1;"><span style="width:9px; height:9px; border-radius:999px; background:${color ?? "#94a3b8"};"></span>${label}</span><strong style="font-size:12px; color:#f8fafc;">${value}</strong></div>`;
 }
+
+const CHART_SET_OPTION_OPTIONS = { lazyUpdate: true } as const;
 
 function EmptyChartState({ message }: { message: string }) {
   return (
@@ -498,8 +502,13 @@ function buildContainerChartOption(
   };
 }
 
-function SystemMetricCard({ panel }: { panel: SystemMetricPanel }) {
+const SystemMetricCard = memo(function SystemMetricCard({
+  panel,
+}: {
+  panel: SystemMetricPanel;
+}) {
   const style = SYSTEM_STYLES[panel.id];
+  const option = useMemo(() => buildSystemChartOption(panel), [panel]);
 
   return (
     <Card
@@ -523,8 +532,8 @@ function SystemMetricCard({ panel }: { panel: SystemMetricPanel }) {
           <EChartSurface
             ariaLabel={`${panel.title} chart`}
             className="h-44"
-            option={buildSystemChartOption(panel)}
-            setOptionOptions={{ lazyUpdate: true }}
+            option={option}
+            setOptionOptions={CHART_SET_OPTION_OPTIONS}
           />
         ) : (
           <EmptyChartState message="Waiting for recent samples for this metric." />
@@ -532,9 +541,17 @@ function SystemMetricCard({ panel }: { panel: SystemMetricPanel }) {
       </CardContent>
     </Card>
   );
-}
+});
 
-function ContainerMetricCard({ panel }: { panel: ContainerMetricPanel }) {
+const ContainerMetricCard = memo(function ContainerMetricCard({
+  panel,
+  loadingMessage,
+}: {
+  loadingMessage: string;
+  panel: ContainerMetricPanel;
+}) {
+  const option = useMemo(() => buildContainerChartOption(panel), [panel]);
+
   return (
     <Card className="overflow-hidden border-border/70 bg-card/94 shadow-[0_30px_80px_-62px_rgba(15,23,42,0.34)]">
       <CardHeader className="gap-4 border-b border-border/60 bg-linear-to-r from-muted/44 via-background to-background pb-4">
@@ -558,20 +575,22 @@ function ContainerMetricCard({ panel }: { panel: ContainerMetricPanel }) {
           <EChartSurface
             ariaLabel={`${panel.title} chart`}
             className="h-96"
-            option={buildContainerChartOption(panel)}
-            setOptionOptions={{ lazyUpdate: true }}
+            option={option}
+            setOptionOptions={CHART_SET_OPTION_OPTIONS}
           />
         ) : (
-          <EmptyChartState message="Waiting for InfluxDB buckets for the selected range." />
+          <EmptyChartState message={loadingMessage} />
         )}
       </CardContent>
     </Card>
   );
-}
+});
 
 export function MetricsDashboardMainContent({
   allContainerHistory,
+  containerHistoryStatusText,
   deployments,
+  isAllContainerHistoryLoading = false,
   onRangeChangeAction,
   range,
   rangeOptions,
@@ -595,6 +614,11 @@ export function MetricsDashboardMainContent({
     [allContainerHistory, deployments, selectedContainerId, snapshot],
   );
   const rangeLabel = formatDashboardRangeLabel(range);
+  const containerEmptyStateMessage = containerHistoryStatusText
+    ? containerHistoryStatusText
+    : isAllContainerHistoryLoading
+      ? "Refreshing container history for the selected range."
+      : "Waiting for InfluxDB buckets for the selected range.";
   const trackedContainers =
     snapshot?.containers.all.length ?? allContainerHistory.length;
   const runningContainers = snapshot?.containers.running ?? trackedContainers;
@@ -674,15 +698,28 @@ export function MetricsDashboardMainContent({
       </section>
 
       <section className="space-y-3">
-        <div className="flex items-center justify-between gap-3">
+        <div className="flex flex-wrap items-center justify-between gap-3">
           <div className="text-sm font-semibold tracking-tight text-foreground">
             Container load explorer
           </div>
+
+          {isAllContainerHistoryLoading || containerHistoryStatusText ? (
+            <div className="flex items-center gap-2 text-xs text-muted-foreground">
+              {isAllContainerHistoryLoading ? (
+                <Badge variant="secondary">Refreshing history…</Badge>
+              ) : null}
+              {containerHistoryStatusText ? <span>{containerHistoryStatusText}</span> : null}
+            </div>
+          ) : null}
         </div>
 
         <div className="space-y-4">
           {containerPanels.map((panel) => (
-            <ContainerMetricCard key={panel.id} panel={panel} />
+            <ContainerMetricCard
+              key={panel.id}
+              loadingMessage={containerEmptyStateMessage}
+              panel={panel}
+            />
           ))}
         </div>
       </section>

--- a/components/workspace/workspace-rail.tsx
+++ b/components/workspace/workspace-rail.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import type { LucideIcon } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useCallback, useEffect } from "react";
 
 import type { WorkspaceView } from "@/components/workspace-shell";
 import { cn } from "@/lib/utils";
@@ -18,11 +20,51 @@ type WorkspaceRailProps = {
   onViewChangeAction: (view: WorkspaceView) => void;
 };
 
+function getWorkspaceRailHref(view: WorkspaceView) {
+  const pathname = view === "dashboard" ? "/" : "/git-app-page";
+
+  if (typeof window === "undefined") {
+    return pathname;
+  }
+
+  const searchParams = new URLSearchParams(window.location.search);
+  const range = searchParams.get("range");
+
+  if (!range) {
+    return pathname;
+  }
+
+  const nextSearchParams = new URLSearchParams({
+    range,
+  });
+
+  return `${pathname}?${nextSearchParams.toString()}`;
+}
+
 export function WorkspaceRail({
   activeView,
   items,
   onViewChangeAction,
 }: WorkspaceRailProps) {
+  const router = useRouter();
+
+  const prefetchView = useCallback(
+    (view: WorkspaceView) => {
+      if (view === activeView) {
+        return;
+      }
+
+      void router.prefetch(getWorkspaceRailHref(view));
+    },
+    [activeView, router],
+  );
+
+  useEffect(() => {
+    items.forEach((item) => {
+      prefetchView(item.id);
+    });
+  }, [items, prefetchView]);
+
   return (
     <aside className="flex w-14 shrink-0 flex-col items-center gap-3 border-r border-border/70 bg-linear-to-b from-background via-muted/22 to-background px-2 py-3 shadow-[16px_0_48px_-44px_rgba(15,23,42,0.26)]">
       <div className="flex w-full flex-col gap-2 pt-1">
@@ -41,6 +83,8 @@ export function WorkspaceRail({
               )}
               key={item.id}
               onClick={() => onViewChangeAction(item.id)}
+              onFocus={() => prefetchView(item.id)}
+              onMouseEnter={() => prefetchView(item.id)}
               title={item.description}
               type="button"
             >

--- a/components/workspace/workspace-route-loading.tsx
+++ b/components/workspace/workspace-route-loading.tsx
@@ -1,0 +1,108 @@
+type WorkspaceRouteLoadingShellProps = {
+  description: string;
+  label: string;
+  title: string;
+};
+
+function LoadingLine({ className }: { className: string }) {
+  return <div className={`${className} animate-pulse rounded-full bg-muted/70`} />;
+}
+
+function LoadingCard({ className = "" }: { className?: string }) {
+  return (
+    <div
+      className={`rounded-[1.5rem] border border-border/70 bg-background/88 p-5 shadow-[0_24px_60px_-48px_rgba(15,23,42,0.3)] ${className}`.trim()}
+    >
+      <LoadingLine className="h-3 w-20" />
+      <LoadingLine className="mt-4 h-7 w-40" />
+      <LoadingLine className="mt-3 h-3.5 w-full max-w-md" />
+      <LoadingLine className="mt-2 h-3.5 w-full max-w-sm" />
+    </div>
+  );
+}
+
+export function WorkspaceRouteLoadingShell({
+  description,
+  label,
+  title,
+}: WorkspaceRouteLoadingShellProps) {
+  return (
+    <section
+      aria-busy="true"
+      aria-label={`${title} loading`}
+      className="flex h-screen flex-col bg-linear-to-b from-background via-muted/12 to-background"
+    >
+      <p className="sr-only">Loading {title}.</p>
+
+      <header className="border-b border-border/70 bg-background/88 px-4 py-3 backdrop-blur md:px-5">
+        <div className="flex items-center justify-between gap-4">
+          <div className="space-y-2">
+            <LoadingLine className="h-3 w-24" />
+            <LoadingLine className="h-7 w-48" />
+          </div>
+
+          <div className="hidden items-center gap-2 md:flex">
+            <LoadingLine className="h-9 w-24" />
+            <LoadingLine className="h-9 w-24" />
+          </div>
+        </div>
+      </header>
+
+      <div className="flex min-w-0 flex-1 overflow-hidden">
+        <aside className="flex w-14 shrink-0 flex-col items-center gap-3 border-r border-border/70 bg-linear-to-b from-background via-muted/22 to-background px-2 py-3">
+          {Array.from({ length: 2 }).map((_, index) => (
+            <LoadingLine className="h-10 w-10 rounded-2xl" key={index} />
+          ))}
+        </aside>
+
+        <aside className="hidden w-[18rem] shrink-0 border-r border-border/70 bg-background/72 p-4 lg:block">
+          <LoadingLine className="h-4 w-32" />
+          <LoadingLine className="mt-4 h-10 w-full rounded-2xl" />
+          <div className="mt-4 space-y-3">
+            {Array.from({ length: 4 }).map((_, index) => (
+              <LoadingLine className="h-16 w-full rounded-[1.25rem]" key={index} />
+            ))}
+          </div>
+        </aside>
+
+        <main className="min-w-0 flex-1 overflow-auto bg-linear-to-b from-background/72 via-muted/14 to-background p-4 md:p-5">
+          <div className="mx-auto flex w-full max-w-6xl flex-col gap-5">
+            <div className="rounded-[1.75rem] border border-border/70 bg-background/86 p-6 shadow-[0_28px_72px_-48px_rgba(15,23,42,0.3)]">
+              <div className="inline-flex items-center rounded-full border border-border/70 bg-background/80 px-3 py-1 text-[11px] font-medium uppercase tracking-[0.24em] text-muted-foreground">
+                {label}
+              </div>
+              <h1 className="mt-4 text-2xl font-semibold tracking-tight text-foreground">
+                {title}
+              </h1>
+              <p className="mt-2 max-w-2xl text-sm leading-6 text-muted-foreground">
+                {description}
+              </p>
+            </div>
+
+            <div className="grid gap-4 xl:grid-cols-[minmax(0,1.6fr)_minmax(18rem,0.9fr)]">
+              <div className="space-y-4">
+                <LoadingCard />
+                <LoadingCard />
+                <LoadingCard className="min-h-72" />
+              </div>
+
+              <div className="space-y-4">
+                <LoadingCard />
+                <LoadingCard className="min-h-80" />
+              </div>
+            </div>
+          </div>
+        </main>
+
+        <aside className="hidden w-[20rem] shrink-0 border-l border-border/70 bg-background/72 p-4 xl:block">
+          <LoadingLine className="h-4 w-28" />
+          <div className="mt-4 space-y-3">
+            {Array.from({ length: 5 }).map((_, index) => (
+              <LoadingLine className="h-14 w-full rounded-[1.25rem]" key={index} />
+            ))}
+          </div>
+        </aside>
+      </div>
+    </section>
+  );
+}

--- a/lib/metrics-dashboard-data.test.ts
+++ b/lib/metrics-dashboard-data.test.ts
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  listDeploymentSummariesMock,
+  getMetricsSnapshotMock,
+  getMetricsHistoryFromInfluxMock,
+  getAllContainersMetricsHistoryFromInfluxMock,
+} = vi.hoisted(() => ({
+  listDeploymentSummariesMock: vi.fn(),
+  getMetricsSnapshotMock: vi.fn(),
+  getMetricsHistoryFromInfluxMock: vi.fn(),
+  getAllContainersMetricsHistoryFromInfluxMock: vi.fn(),
+}));
+
+vi.mock("@/lib/persistence", () => ({
+  listDeploymentSummaries: listDeploymentSummariesMock,
+}));
+
+vi.mock("@/lib/system-metrics", () => ({
+  getMetricsSnapshot: getMetricsSnapshotMock,
+}));
+
+vi.mock("@/lib/influx-metrics", () => ({
+  getAllContainersMetricsHistoryFromInflux:
+    getAllContainersMetricsHistoryFromInfluxMock,
+  getMetricsHistoryFromInflux: getMetricsHistoryFromInfluxMock,
+}));
+
+import { loadMetricsDashboardData } from "@/lib/metrics-dashboard-data";
+
+describe("loadMetricsDashboardData", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("loads deployment summaries without requiring workspace analytics data", async () => {
+    listDeploymentSummariesMock.mockResolvedValue([
+      {
+        id: "dep-1",
+        repositoryName: "dedkola/marketing-site",
+        repositoryUrl: "https://github.com/dedkola/marketing-site.git",
+        branch: "main",
+        commitSha: null,
+        appName: "Marketing Site",
+        subdomain: "marketing",
+        port: 3000,
+        envVariables: null,
+        serviceName: "web",
+        status: "running",
+        composeMode: "compose",
+        projectName: "vercelab-marketing-1234",
+        lastOutput: null,
+        lastOperationSummary: "Healthy",
+        updatedAt: "2026-04-17T08:00:00.000Z",
+        deployedAt: "2026-04-17T07:55:00.000Z",
+        tokenStored: false,
+      },
+    ]);
+    getMetricsSnapshotMock.mockResolvedValue(null);
+
+    const result = await loadMetricsDashboardData();
+
+    expect(listDeploymentSummariesMock).toHaveBeenCalledTimes(1);
+    expect(getMetricsHistoryFromInfluxMock).not.toHaveBeenCalled();
+    expect(getAllContainersMetricsHistoryFromInfluxMock).not.toHaveBeenCalled();
+    expect(result.initialDeployments).toHaveLength(1);
+    expect(result.initialHistory).toEqual([]);
+    expect(result.initialAllContainerHistory).toEqual([]);
+    expect(result.initialSnapshot).toBeNull();
+  });
+});

--- a/lib/metrics-dashboard-data.ts
+++ b/lib/metrics-dashboard-data.ts
@@ -9,7 +9,10 @@ import {
   normalizeDashboardRange,
   type DashboardRange,
 } from "@/lib/metrics-range";
-import { listWorkspaceData, type DeploymentSummary } from "@/lib/persistence";
+import {
+  listDeploymentSummaries,
+  type DeploymentSummary,
+} from "@/lib/persistence";
 import { getMetricsSnapshot, type MetricsSnapshot } from "@/lib/system-metrics";
 
 type MetricsDashboardSearchParams = Promise<{
@@ -38,10 +41,10 @@ export async function loadMetricsDashboardData(
   const { bucketSeconds, limit } = getDashboardHistorySettings(
     initialDashboardRange,
   );
-  const initialSnapshot = await getMetricsSnapshot().catch(() => null);
-  const initialDeployments = await listWorkspaceData()
-    .then((workspaceData) => workspaceData.deployments)
-    .catch(() => [] as DeploymentSummary[]);
+  const [initialSnapshot, initialDeployments] = await Promise.all([
+    getMetricsSnapshot().catch(() => null),
+    listDeploymentSummaries().catch(() => [] as DeploymentSummary[]),
+  ]);
 
   if (!initialSnapshot) {
     return {

--- a/lib/persistence.ts
+++ b/lib/persistence.ts
@@ -185,6 +185,36 @@ type DashboardTrendRow = {
 let pool: Pool | undefined;
 let initPromise: Promise<void> | undefined;
 const trendLabelFormatter = new Intl.DateTimeFormat("en", { weekday: "short" });
+const deploymentSummarySelect = `
+  SELECT
+    d.id,
+    r.name AS repository_name,
+    r.repository_url,
+    r.branch,
+    r.commit_sha,
+    d.app_name,
+    d.subdomain,
+    d.port,
+    d.env_variables,
+    d.service_name,
+    d.status,
+    d.compose_mode,
+    d.project_name,
+    d.last_output,
+    d.updated_at,
+    d.deployed_at,
+    (r.encrypted_token IS NOT NULL) AS token_stored,
+    (
+      SELECT summary
+      FROM operations o
+      WHERE o.deployment_id = d.id
+      ORDER BY o.created_at DESC
+      LIMIT 1
+    ) AS last_operation_summary
+  FROM deployments d
+  INNER JOIN repositories r ON r.id = d.repository_id
+  ORDER BY d.updated_at DESC
+`;
 
 function toSlug(value: string): string {
   return value
@@ -236,6 +266,29 @@ function mapStoredDeployment(row: StoredDeploymentRow): StoredDeployment {
     createdAt: row.created_at,
     updatedAt: row.updated_at,
     deployedAt: row.deployed_at,
+  };
+}
+
+function mapDeploymentSummary(row: DeploymentSummaryRow): DeploymentSummary {
+  return {
+    id: row.id,
+    repositoryName: row.repository_name,
+    repositoryUrl: row.repository_url,
+    branch: row.branch,
+    commitSha: row.commit_sha,
+    appName: row.app_name,
+    subdomain: row.subdomain,
+    port: row.port,
+    envVariables: row.env_variables,
+    serviceName: row.service_name,
+    status: row.status,
+    composeMode: row.compose_mode,
+    projectName: row.project_name,
+    lastOutput: row.last_output,
+    lastOperationSummary: row.last_operation_summary,
+    updatedAt: row.updated_at,
+    deployedAt: row.deployed_at,
+    tokenStored: row.token_stored,
   };
 }
 
@@ -408,38 +461,17 @@ export async function getDatabaseHealth() {
   };
 }
 
+async function queryDeploymentSummaryRows() {
+  return queryRows<DeploymentSummaryRow>(deploymentSummarySelect);
+}
+
+export async function listDeploymentSummaries(): Promise<DeploymentSummary[]> {
+  return (await queryDeploymentSummaryRows()).map(mapDeploymentSummary);
+}
+
 export async function listWorkspaceData(): Promise<WorkspaceData> {
-  const rows = await queryRows<DeploymentSummaryRow>(
-    `
-      SELECT
-        d.id,
-        r.name AS repository_name,
-        r.repository_url,
-        r.branch,
-        r.commit_sha,
-        d.app_name,
-        d.subdomain,
-        d.port,
-        d.env_variables,
-        d.service_name,
-        d.status,
-        d.compose_mode,
-        d.project_name,
-        d.last_output,
-        d.updated_at,
-        d.deployed_at,
-        (r.encrypted_token IS NOT NULL) AS token_stored,
-        (
-          SELECT summary
-          FROM operations o
-          WHERE o.deployment_id = d.id
-          ORDER BY o.created_at DESC
-          LIMIT 1
-        ) AS last_operation_summary
-      FROM deployments d
-      INNER JOIN repositories r ON r.id = d.repository_id
-      ORDER BY d.updated_at DESC
-    `,
+  const deployments = (await queryDeploymentSummaryRows()).map(
+    mapDeploymentSummary,
   );
 
   const activityRows = await queryRows<DashboardActivityRow>(
@@ -482,7 +514,7 @@ export async function listWorkspaceData(): Promise<WorkspaceData> {
     10,
   );
 
-  const stats = rows.reduce(
+  const stats = deployments.reduce(
     (accumulator, deployment) => {
       accumulator.totalDeployments += 1;
 
@@ -508,39 +540,22 @@ export async function listWorkspaceData(): Promise<WorkspaceData> {
   )
     .map((status) => ({
       status,
-      count: rows.filter((row) => row.status === status).length,
+      count: deployments.filter((deployment) => deployment.status === status)
+        .length,
     }))
     .filter((entry) => entry.count > 0);
 
   const modeDistribution = (["dockerfile", "compose", "unknown"] as const)
     .map((mode) => ({
       mode,
-      count: rows.filter((row) => (row.compose_mode ?? "unknown") === mode)
-        .length,
+      count: deployments.filter(
+        (deployment) => (deployment.composeMode ?? "unknown") === mode,
+      ).length,
     }))
     .filter((entry) => entry.count > 0);
 
   return {
-    deployments: rows.map((row) => ({
-      id: row.id,
-      repositoryName: row.repository_name,
-      repositoryUrl: row.repository_url,
-      branch: row.branch,
-      commitSha: row.commit_sha,
-      appName: row.app_name,
-      subdomain: row.subdomain,
-      port: row.port,
-      envVariables: row.env_variables,
-      serviceName: row.service_name,
-      status: row.status,
-      composeMode: row.compose_mode,
-      projectName: row.project_name,
-      lastOutput: row.last_output,
-      lastOperationSummary: row.last_operation_summary,
-      updatedAt: row.updated_at,
-      deployedAt: row.deployed_at,
-      tokenStored: row.token_stored,
-    })),
+    deployments,
     stats: {
       totalDeployments: stats.totalDeployments,
       runningDeployments: stats.runningDeployments,

--- a/lib/workspace-shell-data.test.ts
+++ b/lib/workspace-shell-data.test.ts
@@ -1,0 +1,136 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  getAppConfigMock,
+  listDeploymentSummariesMock,
+  getMetricsSnapshotMock,
+  getMetricsHistoryFromInfluxMock,
+  getContainerMetricsHistoryFromInfluxMock,
+} = vi.hoisted(() => ({
+  getAppConfigMock: vi.fn(),
+  listDeploymentSummariesMock: vi.fn(),
+  getMetricsSnapshotMock: vi.fn(),
+  getMetricsHistoryFromInfluxMock: vi.fn(),
+  getContainerMetricsHistoryFromInfluxMock: vi.fn(),
+}));
+
+vi.mock("@/lib/app-config", () => ({
+  getAppConfig: getAppConfigMock,
+}));
+
+vi.mock("@/lib/persistence", () => ({
+  listDeploymentSummaries: listDeploymentSummariesMock,
+}));
+
+vi.mock("@/lib/system-metrics", () => ({
+  getMetricsSnapshot: getMetricsSnapshotMock,
+}));
+
+vi.mock("@/lib/influx-metrics", () => ({
+  getContainerMetricsHistoryFromInflux: getContainerMetricsHistoryFromInfluxMock,
+  getMetricsHistoryFromInflux: getMetricsHistoryFromInfluxMock,
+}));
+
+import { loadWorkspaceShellData } from "@/lib/workspace-shell-data";
+
+describe("loadWorkspaceShellData", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getAppConfigMock.mockReturnValue({
+      baseDomain: "apps.example.com",
+    });
+  });
+
+  it("skips initial metrics history for git app page first paint", async () => {
+    listDeploymentSummariesMock.mockResolvedValue([
+      {
+        id: "dep-1",
+        repositoryName: "dedkola/marketing-site",
+        repositoryUrl: "https://github.com/dedkola/marketing-site.git",
+        branch: "main",
+        commitSha: null,
+        appName: "Marketing Site",
+        subdomain: "marketing",
+        port: 3000,
+        envVariables: null,
+        serviceName: "web",
+        status: "running",
+        composeMode: "compose",
+        projectName: "vercelab-marketing-1234",
+        lastOutput: null,
+        lastOperationSummary: "Healthy",
+        updatedAt: "2026-04-17T08:00:00.000Z",
+        deployedAt: "2026-04-17T07:55:00.000Z",
+        tokenStored: false,
+      },
+    ]);
+    getMetricsSnapshotMock.mockResolvedValue({
+      hostIp: "10.0.0.7",
+      timestamp: "2026-04-17T08:00:00.000Z",
+      warnings: [],
+      system: {
+        cpuPercent: 12,
+        loadAverage: [0.4, 0.5, 0.6],
+        memoryPercent: 31,
+        memoryUsedBytes: 4_000,
+        memoryTotalBytes: 8_000,
+        diskReadBytesPerSecond: 120,
+        diskWriteBytesPerSecond: 88,
+      },
+      network: {
+        rxBytesPerSecond: 240,
+        txBytesPerSecond: 120,
+        interfaces: [],
+      },
+      containers: {
+        running: 1,
+        total: 1,
+        cpuPercent: 8,
+        memoryPercent: 16,
+        memoryUsedBytes: 512,
+        statusBreakdown: {
+          healthy: 1,
+          unhealthy: 0,
+          stopped: 0,
+        },
+        top: [],
+        all: [
+          {
+            id: "runtime-control-plane",
+            name: "control-plane",
+            cpuPercent: 8,
+            memoryBytes: 512,
+            memoryPercent: 16,
+            networkRxBytesPerSecond: 120,
+            networkTxBytesPerSecond: 80,
+            networkTotalBytesPerSecond: 200,
+            diskReadBytesPerSecond: 0,
+            diskWriteBytesPerSecond: 0,
+            diskTotalBytesPerSecond: 0,
+            status: "running",
+            health: "healthy",
+            projectName: "vercelab-control-plane",
+            serviceName: "web",
+          },
+        ],
+      },
+    });
+
+    const result = await loadWorkspaceShellData(
+      undefined,
+      "git-app-page",
+      {
+        includeMetricsHistory: false,
+      },
+    );
+
+    expect(listDeploymentSummariesMock).toHaveBeenCalledTimes(1);
+    expect(getMetricsHistoryFromInfluxMock).not.toHaveBeenCalled();
+    expect(getContainerMetricsHistoryFromInfluxMock).not.toHaveBeenCalled();
+    expect(result.baseDomain).toBe("apps.example.com");
+    expect(result.initialView).toBe("git-app-page");
+    expect(result.initialHistory).toEqual([]);
+    expect(result.initialContainerHistory).toEqual([]);
+    expect(result.initialDeployments).toHaveLength(1);
+  });
+});

--- a/lib/workspace-shell-data.ts
+++ b/lib/workspace-shell-data.ts
@@ -10,7 +10,10 @@ import {
   normalizeDashboardRange,
   type DashboardRange,
 } from "@/lib/metrics-range";
-import { listWorkspaceData, type DeploymentSummary } from "@/lib/persistence";
+import {
+  listDeploymentSummaries,
+  type DeploymentSummary,
+} from "@/lib/persistence";
 import { getMetricsSnapshot, type MetricsSnapshot } from "@/lib/system-metrics";
 
 type WorkspaceView = "dashboard" | "git-app-page";
@@ -28,6 +31,10 @@ export type WorkspaceShellData = {
   initialHistory: MetricsHistoryPoint[];
   initialView: WorkspaceView;
   initialSnapshot: MetricsSnapshot | null;
+};
+
+type WorkspaceShellDataOptions = {
+  includeMetricsHistory?: boolean;
 };
 
 function getSearchParamValue(value: string | string[] | undefined) {
@@ -53,42 +60,49 @@ function getInitialView(
 export async function loadWorkspaceShellData(
   searchParams?: WorkspaceShellSearchParams,
   defaultView: WorkspaceView = "dashboard",
+  options?: WorkspaceShellDataOptions,
 ): Promise<WorkspaceShellData> {
   const params = searchParams ? await searchParams : undefined;
   const initialDashboardRange = normalizeDashboardRange(
     getSearchParamValue(params?.range),
   );
-  const {
-    bucketSeconds: initialContainerHistoryBucketSeconds,
-    limit: initialContainerHistoryLimit,
-  } = getDashboardHistorySettings(initialDashboardRange);
-  const initialSnapshot = await getMetricsSnapshot().catch(() => null);
+  const includeMetricsHistory = options?.includeMetricsHistory ?? true;
+  const [initialSnapshot, initialDeployments] = await Promise.all([
+    getMetricsSnapshot().catch(() => null),
+    listDeploymentSummaries().catch(() => [] as DeploymentSummary[]),
+  ]);
   const initialFocusedContainer = initialSnapshot?.containers.all[0] ?? null;
-  const [initialHistory, initialContainerHistory] = initialSnapshot
-    ? await Promise.all([
-        getMetricsHistoryFromInflux({
-          hostIp: initialSnapshot.hostIp,
-          limit: 48,
-          bucketSeconds: 5,
-        }).catch(() => []),
-        initialFocusedContainer
-          ? getContainerMetricsHistoryFromInflux({
-              hostIp: initialSnapshot.hostIp,
-              containerId: initialFocusedContainer.id,
-              containerName: initialFocusedContainer.name,
-              limit: initialContainerHistoryLimit,
-              bucketSeconds: initialContainerHistoryBucketSeconds,
-            }).catch(() => [])
-          : Promise.resolve([] as ContainerMetricsHistoryPoint[]),
-      ])
-    : ([[], []] as [MetricsHistoryPoint[], ContainerMetricsHistoryPoint[]]);
-  const workspaceData = await listWorkspaceData();
+  const [initialHistory, initialContainerHistory] =
+    includeMetricsHistory && initialSnapshot
+      ? await Promise.all([
+          getMetricsHistoryFromInflux({
+            hostIp: initialSnapshot.hostIp,
+            limit: 48,
+            bucketSeconds: 5,
+          }).catch(() => [] as MetricsHistoryPoint[]),
+          initialFocusedContainer
+            ? (() => {
+                const { bucketSeconds, limit } = getDashboardHistorySettings(
+                  initialDashboardRange,
+                );
+
+                return getContainerMetricsHistoryFromInflux({
+                  hostIp: initialSnapshot.hostIp,
+                  containerId: initialFocusedContainer.id,
+                  containerName: initialFocusedContainer.name,
+                  limit,
+                  bucketSeconds,
+                }).catch(() => [] as ContainerMetricsHistoryPoint[]);
+              })()
+            : Promise.resolve([] as ContainerMetricsHistoryPoint[]),
+        ])
+      : ([[], []] as [MetricsHistoryPoint[], ContainerMetricsHistoryPoint[]]);
 
   return {
     baseDomain: getAppConfig().baseDomain,
     initialContainerHistory,
     initialDashboardRange,
-    initialDeployments: workspaceData.deployments,
+    initialDeployments,
     initialHistory,
     initialView: getInitialView(params?.page, defaultView),
     initialSnapshot,

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -13,3 +13,11 @@ Object.defineProperty(window.HTMLElement.prototype, "scrollIntoView", {
   configurable: true,
   value() {},
 });
+
+class IntersectionObserverMock {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+vi.stubGlobal("IntersectionObserver", IntersectionObserverMock);


### PR DESCRIPTION
## Summary
- split metrics loading so live polling stays lightweight and heavy history is fetched explicitly
- reduce first-paint server work by using deployment summaries and skipping eager Git App Page history
- improve perceived performance with route loading fallbacks, route prefetching, and lazy ECharts warmup

## Testing
- pnpm run lint
- pnpm run build
- pnpm run test:run